### PR TITLE
[codex] roll out TanStack DB read model

### DIFF
--- a/src/NatsManager.Frontend/package-lock.json
+++ b/src/NatsManager.Frontend/package-lock.json
@@ -15,6 +15,8 @@
         "@mantine/notifications": "9.1.1",
         "@microsoft/signalr": "^10.0.0",
         "@tabler/icons-react": "3.43.0",
+        "@tanstack/query-db-collection": "^1.0.36",
+        "@tanstack/react-db": "^0.1.83",
         "@tanstack/react-query": "5.100.9",
         "@tanstack/react-virtual": "3.13.24",
         "@xyflow/react": "12.10.2",
@@ -1443,6 +1445,46 @@
         "react": ">= 16"
       }
     },
+    "node_modules/@tanstack/db": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/db/-/db-0.6.5.tgz",
+      "integrity": "sha512-gtCuAo4UtC9SR/kTMu5fVEff6qZ2R1FZi9X7MybtHKA6wve7RePifGG6qBI4OmMB+7juT5/+glNbnqZOrG0/pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@tanstack/db-ivm": "0.1.18",
+        "@tanstack/pacer-lite": "^0.2.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@tanstack/db-ivm": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/db-ivm/-/db-ivm-0.1.18.tgz",
+      "integrity": "sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==",
+      "license": "MIT",
+      "dependencies": {
+        "fractional-indexing": "^3.2.0",
+        "sorted-btree": "^1.8.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@tanstack/pacer-lite": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer-lite/-/pacer-lite-0.2.1.tgz",
+      "integrity": "sha512-3PouiFjR4B6x1c969/Pl4ZIJleof1M0n6fNX8NRiC9Sqv1g06CVDlEaXUR4212ycGFyfq4q+t8Gi37Xy+z34iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.9",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
@@ -1451,6 +1493,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-db-collection": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-db-collection/-/query-db-collection-1.0.36.tgz",
+      "integrity": "sha512-WOHSZeqFOflWpMxp7ndu8x3M8GyLieWyUsS1fReG8wv6I/1MGOz1j3+XNlGoeoWolYF2hV4l324/dB9BxjAwxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@tanstack/db": "0.6.5"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": "^5.0.0",
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@tanstack/react-db": {
+      "version": "0.1.83",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-db/-/react-db-0.1.83.tgz",
+      "integrity": "sha512-LNV0C7OARazooT2hLTr5anXo6tbEyX2rHZQ0j9HZ/iNBI+Tx/y19o5Nd3ooyAYz5LEHJJxb8iM8ZTVB/diGnXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/db": "0.6.5",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@tanstack/react-query": {
@@ -3493,6 +3562,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fractional-indexing": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-3.2.0.tgz",
+      "integrity": "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==",
+      "license": "CC0-1.0",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5391,6 +5469,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sorted-btree": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sorted-btree/-/sorted-btree-1.8.1.tgz",
+      "integrity": "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5681,7 +5765,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/NatsManager.Frontend/package.json
+++ b/src/NatsManager.Frontend/package.json
@@ -19,6 +19,8 @@
     "@mantine/notifications": "9.1.1",
     "@microsoft/signalr": "^10.0.0",
     "@tabler/icons-react": "3.43.0",
+    "@tanstack/query-db-collection": "^1.0.36",
+    "@tanstack/react-db": "^0.1.83",
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-virtual": "3.13.24",
     "@xyflow/react": "12.10.2",

--- a/src/NatsManager.Frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/NatsManager.Frontend/src/features/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { useEnvironmentContext } from '../environments/EnvironmentContext';
 import { LoadingState } from '../../shared/LoadingState';
 import { EmptyState } from '../../shared/EmptyState';
 import { useDashboardHealth, useDashboardJetStream } from '../../read-model/projections';
+import type { DashboardSummary } from './types';
 
 export default function DashboardPage() {
   const { selectedEnvironmentId } = useEnvironmentContext();
@@ -45,13 +46,7 @@ export default function DashboardPage() {
     );
   }
 
-  const connectionStatus = readModelHealth.connectionStatus === 'Connected'
-    ? 'Available'
-    : readModelHealth.connectionStatus === 'Reconnecting'
-      ? 'Degraded'
-      : readModelHealth.connectionStatus === 'Disconnected' && readModelHealth.lastUpdatedUtc
-        ? 'Unavailable'
-        : data.environment.connectionStatus;
+  const connectionStatus = getConnectionStatus(readModelHealth.connectionStatus, readModelHealth.lastUpdatedUtc, data.environment.connectionStatus);
   const jetStream = readModelJetStream.isEnabled === null
     ? data.jetStream
     : {
@@ -135,4 +130,15 @@ export default function DashboardPage() {
       )}
     </Stack>
   );
+}
+
+function getConnectionStatus(
+  connectionStatus: ReturnType<typeof useDashboardHealth>['connectionStatus'],
+  lastUpdatedUtc: string | null,
+  fallbackStatus: DashboardSummary['environment']['connectionStatus'],
+) {
+  if (connectionStatus === 'Connected') return 'Available';
+  if (connectionStatus === 'Reconnecting') return 'Degraded';
+  if (connectionStatus === 'Disconnected' && lastUpdatedUtc) return 'Unavailable';
+  return fallbackStatus;
 }

--- a/src/NatsManager.Frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/NatsManager.Frontend/src/features/dashboard/DashboardPage.tsx
@@ -10,10 +10,13 @@ import { useDashboard } from './hooks/useDashboard';
 import { useEnvironmentContext } from '../environments/EnvironmentContext';
 import { LoadingState } from '../../shared/LoadingState';
 import { EmptyState } from '../../shared/EmptyState';
+import { useDashboardHealth, useDashboardJetStream } from '../../read-model/projections';
 
 export default function DashboardPage() {
   const { selectedEnvironmentId } = useEnvironmentContext();
   const { data, isLoading, error } = useDashboard(selectedEnvironmentId);
+  const readModelHealth = useDashboardHealth(selectedEnvironmentId);
+  const readModelJetStream = useDashboardJetStream(selectedEnvironmentId);
 
   if (!selectedEnvironmentId) {
     return (
@@ -42,6 +45,23 @@ export default function DashboardPage() {
     );
   }
 
+  const connectionStatus = readModelHealth.connectionStatus === 'Connected'
+    ? 'Available'
+    : readModelHealth.connectionStatus === 'Reconnecting'
+      ? 'Degraded'
+      : readModelHealth.connectionStatus === 'Disconnected' && readModelHealth.lastUpdatedUtc
+        ? 'Unavailable'
+        : data.environment.connectionStatus;
+  const jetStream = readModelJetStream.isEnabled === null
+    ? data.jetStream
+    : {
+        ...data.jetStream,
+        streamCount: readModelJetStream.streamCount,
+        consumerCount: readModelJetStream.consumerCount,
+        totalMessages: readModelJetStream.totalMessages,
+        totalBytes: readModelJetStream.totalBytes,
+      };
+
   return (
     <Stack>
       <Title order={2}>Dashboard</Title>
@@ -50,12 +70,12 @@ export default function DashboardPage() {
         <Card shadow="sm" padding="lg" radius="md" withBorder>
           <Group justify="space-between" mb="xs">
             <Text size="sm" c="dimmed" fw={500}>Connection Status</Text>
-            <ThemeIcon variant="light" color={data.environment.connectionStatus === 'Available' ? 'green' : 'red'} size="md" radius="md">
+            <ThemeIcon variant="light" color={connectionStatus === 'Available' ? 'green' : 'red'} size="md" radius="md">
               <IconPlugConnected size={16} />
             </ThemeIcon>
           </Group>
-          <Badge color={data.environment.connectionStatus === 'Available' ? 'green' : 'red'} size="lg" variant="light">
-            {data.environment.connectionStatus}
+          <Badge color={connectionStatus === 'Available' ? 'green' : 'red'} size="lg" variant="light">
+            {connectionStatus}
           </Badge>
         </Card>
 
@@ -66,11 +86,11 @@ export default function DashboardPage() {
               <IconBolt size={16} />
             </ThemeIcon>
           </Group>
-          <Text size="xl" fw={700}>{data.jetStream.streamCount}</Text>
+          <Text size="xl" fw={700}>{jetStream.streamCount}</Text>
           <Group gap="xs" mt="xs">
-            <Text size="sm" c="dimmed">{data.jetStream.consumerCount} consumers</Text>
-            {data.jetStream.unhealthyConsumers > 0 && (
-              <Badge color="red" size="sm" variant="light">{data.jetStream.unhealthyConsumers} unhealthy</Badge>
+            <Text size="sm" c="dimmed">{jetStream.consumerCount} consumers</Text>
+            {jetStream.unhealthyConsumers > 0 && (
+              <Badge color="red" size="sm" variant="light">{jetStream.unhealthyConsumers} unhealthy</Badge>
             )}
           </Group>
         </Card>
@@ -93,8 +113,8 @@ export default function DashboardPage() {
               <IconMail size={16} />
             </ThemeIcon>
           </Group>
-          <Text size="xl" fw={700}>{data.jetStream.totalMessages.toLocaleString()}</Text>
-          <Text size="sm" c="dimmed" mt="xs">{(data.jetStream.totalBytes / 1024 / 1024).toFixed(1)} MB</Text>
+          <Text size="xl" fw={700}>{jetStream.totalMessages.toLocaleString()}</Text>
+          <Text size="sm" c="dimmed" mt="xs">{(jetStream.totalBytes / 1024 / 1024).toFixed(1)} MB</Text>
         </Card>
       </SimpleGrid>
 

--- a/src/NatsManager.Frontend/src/features/environments/EnvironmentProvider.tsx
+++ b/src/NatsManager.Frontend/src/features/environments/EnvironmentProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { EnvironmentContext } from './EnvironmentContext';
 import { writeSelectedEnvironment } from '../../read-model/sync/environment-status-sync';
 
@@ -6,13 +6,15 @@ const STORAGE_KEY = 'nats-admin:selectedEnvironmentId';
 
 export function EnvironmentProvider({ children }: { children: ReactNode }) {
   const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<string | null>(() => sessionStorage.getItem(STORAGE_KEY));
+  const initialSelectedEnvironmentId = useRef(selectedEnvironmentId);
 
   useEffect(() => {
-    writeSelectedEnvironment(selectedEnvironmentId, new Date().toISOString());
-  }, [selectedEnvironmentId]);
+    writeSelectedEnvironment(initialSelectedEnvironmentId.current, new Date().toISOString());
+  }, []);
 
   const selectEnvironment = useCallback((id: string | null) => {
     setSelectedEnvironmentId(id);
+    writeSelectedEnvironment(id);
     if (id) {
       sessionStorage.setItem(STORAGE_KEY, id);
     } else {

--- a/src/NatsManager.Frontend/src/features/environments/EnvironmentProvider.tsx
+++ b/src/NatsManager.Frontend/src/features/environments/EnvironmentProvider.tsx
@@ -1,19 +1,18 @@
-import { useCallback, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { EnvironmentContext } from './EnvironmentContext';
 import { writeSelectedEnvironment } from '../../read-model/sync/environment-status-sync';
 
 const STORAGE_KEY = 'nats-admin:selectedEnvironmentId';
 
 export function EnvironmentProvider({ children }: { children: ReactNode }) {
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<string | null>(() => {
-    const storedEnvironmentId = sessionStorage.getItem(STORAGE_KEY);
-    writeSelectedEnvironment(storedEnvironmentId, new Date().toISOString());
-    return storedEnvironmentId;
-  });
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<string | null>(() => sessionStorage.getItem(STORAGE_KEY));
+
+  useEffect(() => {
+    writeSelectedEnvironment(selectedEnvironmentId, new Date().toISOString());
+  }, [selectedEnvironmentId]);
 
   const selectEnvironment = useCallback((id: string | null) => {
     setSelectedEnvironmentId(id);
-    writeSelectedEnvironment(id);
     if (id) {
       sessionStorage.setItem(STORAGE_KEY, id);
     } else {

--- a/src/NatsManager.Frontend/src/features/environments/EnvironmentProvider.tsx
+++ b/src/NatsManager.Frontend/src/features/environments/EnvironmentProvider.tsx
@@ -1,15 +1,19 @@
 import { useCallback, useState, type ReactNode } from 'react';
 import { EnvironmentContext } from './EnvironmentContext';
+import { writeSelectedEnvironment } from '../../read-model/sync/environment-status-sync';
 
 const STORAGE_KEY = 'nats-admin:selectedEnvironmentId';
 
 export function EnvironmentProvider({ children }: { children: ReactNode }) {
   const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<string | null>(() => {
-    return sessionStorage.getItem(STORAGE_KEY);
+    const storedEnvironmentId = sessionStorage.getItem(STORAGE_KEY);
+    writeSelectedEnvironment(storedEnvironmentId, new Date().toISOString());
+    return storedEnvironmentId;
   });
 
   const selectEnvironment = useCallback((id: string | null) => {
     setSelectedEnvironmentId(id);
+    writeSelectedEnvironment(id);
     if (id) {
       sessionStorage.setItem(STORAGE_KEY, id);
     } else {

--- a/src/NatsManager.Frontend/src/features/environments/hooks/useEnvironments.ts
+++ b/src/NatsManager.Frontend/src/features/environments/hooks/useEnvironments.ts
@@ -11,14 +11,17 @@ import type {
   UpdateEnvironmentRequest,
   TestConnectionResult,
 } from '../types';
+import { syncEnvironmentStatus, syncEnvironmentStatuses } from '../../../read-model/sync/environment-status-sync';
 
 export function useEnvironments(params?: PaginatedQueryParams) {
   return useQuery({
     queryKey: queryKeys.environmentList(params),
     queryFn: async (): Promise<{ data: PaginatedResult<EnvironmentListItem>; freshness: DataFreshness }> => {
       const response = await apiClient.get(apiEndpoints.environments(), { params });
+      const data = response.data as PaginatedResult<EnvironmentListItem>;
+      syncEnvironmentStatuses(data.items);
       return {
-        data: response.data as PaginatedResult<EnvironmentListItem>,
+        data,
         freshness: extractDataFreshness(response.headers as Record<string, string>),
       };
     },
@@ -30,7 +33,9 @@ export function useEnvironment(id: string | undefined) {
     queryKey: queryKeys.environmentDetail(id),
     queryFn: async (): Promise<EnvironmentDetail> => {
       const response = await apiClient.get(apiEndpoints.environmentDetail(id));
-      return response.data as EnvironmentDetail;
+      const data = response.data as EnvironmentDetail;
+      syncEnvironmentStatus(data);
+      return data;
     },
     enabled: !!id,
   });

--- a/src/NatsManager.Frontend/src/features/jetstream/hooks/useJetStream.ts
+++ b/src/NatsManager.Frontend/src/features/jetstream/hooks/useJetStream.ts
@@ -4,13 +4,16 @@ import { apiEndpoints } from '../../../api/endpoints';
 import { queryKeys } from '../../../api/queryKeys';
 import type { PaginatedResult, PaginatedQueryParams } from '../../../api/types';
 import type { StreamListItem, StreamDetail, ConsumerInfo, CreateStreamRequest, UpdateStreamRequest, CreateConsumerRequest, StreamMessageItem } from '../types';
+import { syncConsumer, syncConsumers, syncStreamDetail, syncStreams } from '../../../read-model/sync/jetstream-query-sync';
 
 export function useStreams(environmentId: string | null, params?: PaginatedQueryParams) {
   return useQuery({
     queryKey: queryKeys.streams(environmentId, params),
     queryFn: async () => {
       const response = await apiClient.get(apiEndpoints.streamList(environmentId), { params });
-      return response.data as PaginatedResult<StreamListItem>;
+      const data = response.data as PaginatedResult<StreamListItem>;
+      if (environmentId) syncStreams(environmentId, data.items);
+      return data;
     },
     enabled: !!environmentId,
   });
@@ -21,7 +24,9 @@ export function useStream(environmentId: string | null, streamName: string | und
     queryKey: queryKeys.streamDetail(environmentId, streamName),
     queryFn: async () => {
       const response = await apiClient.get(apiEndpoints.streamDetail(environmentId, streamName));
-      return response.data as StreamDetail;
+      const data = response.data as StreamDetail;
+      if (environmentId) syncStreamDetail(environmentId, data);
+      return data;
     },
     enabled: !!environmentId && !!streamName,
   });
@@ -32,7 +37,9 @@ export function useConsumers(environmentId: string | null, streamName: string | 
     queryKey: queryKeys.consumers(environmentId, streamName, params),
     queryFn: async () => {
       const response = await apiClient.get(apiEndpoints.consumerList(environmentId, streamName), { params });
-      return response.data as PaginatedResult<ConsumerInfo>;
+      const data = response.data as PaginatedResult<ConsumerInfo>;
+      if (environmentId && streamName) syncConsumers(environmentId, streamName, data.items);
+      return data;
     },
     enabled: !!environmentId && !!streamName,
   });
@@ -43,7 +50,9 @@ export function useConsumer(environmentId: string | null, streamName: string | u
     queryKey: queryKeys.consumerDetail(environmentId, streamName, consumerName),
     queryFn: async () => {
       const response = await apiClient.get(apiEndpoints.consumerDetail(environmentId, streamName, consumerName));
-      return response.data as ConsumerInfo;
+      const data = response.data as ConsumerInfo;
+      if (environmentId && streamName) syncConsumer(environmentId, streamName, data);
+      return data;
     },
     enabled: !!environmentId && !!streamName && !!consumerName,
   });

--- a/src/NatsManager.Frontend/src/features/monitoring/cluster-observability/components/ClusterOverviewCard.tsx
+++ b/src/NatsManager.Frontend/src/features/monitoring/cluster-observability/components/ClusterOverviewCard.tsx
@@ -98,7 +98,7 @@ export function ClusterOverviewCard({ observation }: ClusterOverviewCardProps) {
             <Text size="xs" c="dimmed">Connections</Text>
             <Group gap="xs" align="baseline">
               <Text size="xl" fw={700}>
-                {observation.connectionCount?.toLocaleString() ?? '—'}
+                {observation.connectionCount?.toLocaleString('en-US') ?? '—'}
               </Text>
               <IconPlugConnected size={14} stroke={1.5} />
             </Group>

--- a/src/NatsManager.Frontend/src/features/monitoring/hooks/useMonitoringHub.ts
+++ b/src/NatsManager.Frontend/src/features/monitoring/hooks/useMonitoringHub.ts
@@ -1,10 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as signalR from '@microsoft/signalr';
 import axios from 'axios';
 import { apiClient } from '../../../api/client';
 import type { MonitoringSnapshot, MonitoringHistoryResult, MonitoringConnectionStatus } from '../types';
-
-const MAX_SNAPSHOTS = 120;
+import { useMonitoringEnvironmentState, useRecentMonitoringSnapshots } from '../../../read-model/hooks';
+import {
+  toMonitoringSnapshot,
+  writeMonitoringHistory,
+  writeMonitoringSnapshot,
+  writeMonitoringState,
+} from '../../../read-model/sync/monitoring-hub-sync';
+import type { ReadModelConnectionStatus } from '../../../read-model/types/common';
 
 interface UseMonitoringHubResult {
   snapshots: MonitoringSnapshot[];
@@ -15,11 +21,12 @@ interface UseMonitoringHubResult {
 }
 
 export function useMonitoringHub(environmentId: string | null): UseMonitoringHubResult {
-  const [snapshots, setSnapshots] = useState<MonitoringSnapshot[]>([]);
-  const [connectionStatus, setConnectionStatus] = useState<MonitoringConnectionStatus>('connecting');
-  const [isNotConfigured, setIsNotConfigured] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const connectionRef = useRef<signalR.HubConnection | null>(null);
+  const snapshotsQuery = useRecentMonitoringSnapshots(environmentId, 120);
+  const stateQuery = useMonitoringEnvironmentState(environmentId);
+  const [localConnectionStatus, setLocalConnectionStatus] = useState<MonitoringConnectionStatus>('connecting');
+  const [localIsNotConfigured, setLocalIsNotConfigured] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!environmentId) return;
@@ -27,9 +34,10 @@ export function useMonitoringHub(environmentId: string | null): UseMonitoringHub
     let cancelled = false;
 
     const start = async () => {
-      setConnectionStatus('connecting');
-      setIsNotConfigured(false);
-      setError(null);
+      setLocalConnectionStatus('connecting');
+      setLocalIsNotConfigured(false);
+      setLocalError(null);
+      writeMonitoringState(environmentId, 'Connecting', null, false);
 
       // Fetch initial history
       try {
@@ -37,25 +45,24 @@ export function useMonitoringHub(environmentId: string | null): UseMonitoringHub
           `/environments/${environmentId}/monitoring/metrics/history`
         );
         if (!cancelled) {
-          // History comes oldest→newest; we display newest-first in state (prepended)
-          setSnapshots([...response.data.snapshots].reverse());
+          writeMonitoringHistory(environmentId, response.data.snapshots);
         }
       } catch (err) {
         if (axios.isAxiosError(err) && err.response?.status === 400) {
           if (!cancelled) {
-            setSnapshots([]);
-            setIsNotConfigured(true);
-            setConnectionStatus('disconnected');
-            setError('Monitoring is not configured for this environment.');
+            setLocalIsNotConfigured(true);
+            setLocalConnectionStatus('disconnected');
+            setLocalError('Monitoring is not configured for this environment.');
+            writeMonitoringState(environmentId, 'Disconnected', 'Monitoring is not configured for this environment.', true);
           }
           return;
         }
 
         if (axios.isAxiosError(err) && err.response?.status === 404) {
           if (!cancelled) {
-            setSnapshots([]);
-            setConnectionStatus('disconnected');
-            setError('Environment not found.');
+            setLocalConnectionStatus('disconnected');
+            setLocalError('Environment not found.');
+            writeMonitoringState(environmentId, 'Disconnected', 'Environment not found.', false);
           }
           return;
         }
@@ -72,25 +79,32 @@ export function useMonitoringHub(environmentId: string | null): UseMonitoringHub
       connectionRef.current = connection;
 
       connection.onreconnecting(() => {
-        if (!cancelled) setConnectionStatus('reconnecting');
+        if (!cancelled) {
+          setLocalConnectionStatus('reconnecting');
+          writeMonitoringState(environmentId, 'Reconnecting', null, false);
+        }
       });
 
       connection.onreconnected(() => {
         if (!cancelled) {
-          setConnectionStatus('connected');
+          setLocalConnectionStatus('connected');
+          writeMonitoringState(environmentId, 'Connected', null, false);
           void connection.invoke('SubscribeToEnvironment', environmentId);
         }
       });
 
       connection.onclose(() => {
-        if (!cancelled) setConnectionStatus('disconnected');
+        if (!cancelled) {
+          setLocalConnectionStatus('disconnected');
+          writeMonitoringState(environmentId, 'Disconnected', 'Connection lost. Attempting to reconnect…', false);
+        }
       });
 
       connection.on('ReceiveMonitoringSnapshot', (snapshot: MonitoringSnapshot) => {
         if (!cancelled) {
-          setSnapshots(prev => [snapshot, ...prev].slice(0, MAX_SNAPSHOTS));
-          setIsNotConfigured(false);
-          setError(null);
+          writeMonitoringSnapshot(snapshot, 'Connected');
+          setLocalIsNotConfigured(false);
+          setLocalError(null);
         }
       });
 
@@ -100,12 +114,15 @@ export function useMonitoringHub(environmentId: string | null): UseMonitoringHub
           await connection.stop();
           return;
         }
-        setConnectionStatus('connected');
+        setLocalConnectionStatus('connected');
+        writeMonitoringState(environmentId, 'Connected', null, false);
         await connection.invoke('SubscribeToEnvironment', environmentId);
       } catch (err) {
         if (!cancelled) {
-          setConnectionStatus('disconnected');
-          setError(err instanceof Error ? err.message : 'Failed to connect');
+          const message = err instanceof Error ? err.message : 'Failed to connect';
+          setLocalConnectionStatus('disconnected');
+          setLocalError(message);
+          writeMonitoringState(environmentId, 'Disconnected', message, false);
         }
       }
     };
@@ -125,11 +142,28 @@ export function useMonitoringHub(environmentId: string | null): UseMonitoringHub
     };
   }, [environmentId]);
 
+  const snapshots = useMemo(
+    () => snapshotsQuery.data.map(toMonitoringSnapshot),
+    [snapshotsQuery.data],
+  );
+  const state = stateQuery.data;
+  const connectionStatus = toMonitoringConnectionStatus(state?.connectionStatus) ?? localConnectionStatus;
+
   return {
     snapshots,
     latestSnapshot: snapshots[0] ?? null,
     connectionStatus,
-    isNotConfigured,
-    error,
+    isNotConfigured: state?.isNotConfigured ?? localIsNotConfigured,
+    error: state?.errorMessage ?? localError,
   };
+}
+
+function toMonitoringConnectionStatus(status: ReadModelConnectionStatus | undefined): MonitoringConnectionStatus | null {
+  switch (status) {
+    case 'Connected': return 'connected';
+    case 'Connecting': return 'connecting';
+    case 'Disconnected': return 'disconnected';
+    case 'Reconnecting': return 'reconnecting';
+    default: return null;
+  }
 }

--- a/src/NatsManager.Frontend/src/features/relationships/hooks/useResourceRelationshipMap.ts
+++ b/src/NatsManager.Frontend/src/features/relationships/hooks/useResourceRelationshipMap.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { apiClient } from '../../../api/client';
 import type { RelationshipMap, ResourceType, MapFilter, ResourceNode } from '../types';
+import { syncRelationshipMap } from '../../../read-model/sync/relationship-map-sync';
 
 interface UseResourceRelationshipMapOptions {
   environmentId: string | null;
@@ -72,6 +73,7 @@ export function useResourceRelationshipMap({
       const response = await apiClient.get<RelationshipMap>(
         `/environments/${environmentId}/relationships/map?${params.toString()}`
       );
+      syncRelationshipMap(response.data);
       return response.data;
     },
     enabled,

--- a/src/NatsManager.Frontend/src/features/search/hooks/useSearch.ts
+++ b/src/NatsManager.Frontend/src/features/search/hooks/useSearch.ts
@@ -1,18 +1,40 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../../../api/client';
 import type { SearchResult, BookmarkDto, UserPreferenceDto, CreateBookmarkRequest } from '../types';
+import { useGlobalResourceSearch } from '../../../read-model/hooks';
+import { syncSearchResults } from '../../../read-model/sync/resource-query-sync';
 
 export function useSearch(query: string, resourceType?: string) {
-  return useQuery({
+  const localSearch = useGlobalResourceSearch({
+    query,
+    resourceType: resourceType ?? null,
+    sortBy: 'relevance',
+  });
+  const serverSearch = useQuery({
     queryKey: ['search', query, resourceType],
     queryFn: async () => {
       const params: Record<string, string> = { q: query };
       if (resourceType) params.type = resourceType;
       const res = await apiClient.get<SearchResult[]>('/search', { params });
+      syncSearchResults(res.data);
       return res.data;
     },
     enabled: query.length >= 2,
   });
+
+  const localResults: SearchResult[] = localSearch.data.map(result => ({
+    resourceType: result.resourceType,
+    resourceId: result.resourceId,
+    displayName: result.displayName,
+    environmentId: result.environmentId,
+    description: result.description ?? undefined,
+  }));
+
+  return {
+    ...serverSearch,
+    data: serverSearch.data ?? (localResults.length > 0 ? localResults : undefined),
+    isFetching: serverSearch.isFetching || localSearch.isLoading,
+  };
 }
 
 export function useBookmarks() {

--- a/src/NatsManager.Frontend/src/read-model/collections/consumers.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/consumers.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { ConsumerRecord } from '../types/jetstream-read-model';
+
+export const consumersCollection = createCollection<ConsumerRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'jetstream-consumers',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/environment-status.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/environment-status.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { EnvironmentStatusRecord } from '../types/environment-read-model';
+
+export const environmentStatusCollection = createCollection<EnvironmentStatusRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'environment-status',
+    getKey: record => record.environmentId,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/index.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/index.ts
@@ -1,0 +1,10 @@
+export { monitoringSnapshotsCollection } from './monitoring-snapshots.collection';
+export { monitoringEnvironmentStateCollection } from './monitoring-environment-state.collection';
+export { environmentStatusCollection } from './environment-status.collection';
+export { selectedEnvironmentCollection } from './selected-environment.collection';
+export { resourceIndexCollection } from './resource-index.collection';
+export { relationshipNodesCollection } from './relationship-nodes.collection';
+export { relationshipEdgesCollection } from './relationship-edges.collection';
+export { relationshipEvidenceCollection } from './relationship-evidence.collection';
+export { streamsCollection } from './streams.collection';
+export { consumersCollection } from './consumers.collection';

--- a/src/NatsManager.Frontend/src/read-model/collections/monitoring-environment-state.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/monitoring-environment-state.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { MonitoringEnvironmentStateRecord } from '../types/monitoring-read-model';
+
+export const monitoringEnvironmentStateCollection = createCollection<MonitoringEnvironmentStateRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'monitoring-environment-state',
+    getKey: record => record.environmentId,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/monitoring-snapshots.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/monitoring-snapshots.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { MonitoringSnapshotRecord } from '../types/monitoring-read-model';
+
+export const monitoringSnapshotsCollection = createCollection<MonitoringSnapshotRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'monitoring-snapshots',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/relationship-edges.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/relationship-edges.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { RelationshipEdgeRecord } from '../types/relationship-read-model';
+
+export const relationshipEdgesCollection = createCollection<RelationshipEdgeRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'relationship-edges',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/relationship-evidence.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/relationship-evidence.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { RelationshipEvidenceRecord } from '../types/relationship-read-model';
+
+export const relationshipEvidenceCollection = createCollection<RelationshipEvidenceRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'relationship-evidence',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/relationship-nodes.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/relationship-nodes.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { RelationshipNodeRecord } from '../types/relationship-read-model';
+
+export const relationshipNodesCollection = createCollection<RelationshipNodeRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'relationship-nodes',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/resource-index.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/resource-index.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { ResourceIndexItemRecord } from '../types/resource-index-read-model';
+
+export const resourceIndexCollection = createCollection<ResourceIndexItemRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'resource-index',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/selected-environment.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/selected-environment.collection.ts
@@ -1,0 +1,16 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { SelectedEnvironmentRecord } from '../types/environment-read-model';
+
+const initialSelectedEnvironment: SelectedEnvironmentRecord = {
+  id: 'selected-environment',
+  environmentId: null,
+  selectedAtUtc: null,
+};
+
+export const selectedEnvironmentCollection = createCollection<SelectedEnvironmentRecord, string>(
+  localOnlyCollectionOptions<SelectedEnvironmentRecord, string>({
+    id: 'selected-environment',
+    getKey: record => record.id,
+    initialData: [initialSelectedEnvironment],
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/collections/streams.collection.ts
+++ b/src/NatsManager.Frontend/src/read-model/collections/streams.collection.ts
@@ -1,0 +1,9 @@
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/react-db';
+import type { StreamRecord } from '../types/jetstream-read-model';
+
+export const streamsCollection = createCollection<StreamRecord, string>(
+  localOnlyCollectionOptions({
+    id: 'jetstream-streams',
+    getKey: record => record.id,
+  }),
+);

--- a/src/NatsManager.Frontend/src/read-model/hooks/index.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useLatestMonitoringSnapshot } from './use-latest-monitoring-snapshot';
+export { useRecentMonitoringSnapshots } from './use-recent-monitoring-snapshots';
+export { useMonitoringEnvironmentState } from './use-monitoring-environment-state';
+export { useGlobalResourceSearch } from './use-global-resource-search';
+export { useRelationshipMapProjection } from './use-relationship-map-projection';

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-global-resource-search.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-global-resource-search.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from '@tanstack/react-db';
+import { resourceIndexCollection } from '../collections';
+import type { GlobalResourceSearchOptions } from '../types/resource-index-read-model';
+
+export function useGlobalResourceSearch(options: GlobalResourceSearchOptions) {
+  const { data = [], ...query } = useLiveQuery((q) => q.from({ resource: resourceIndexCollection }), []);
+  const normalizedQuery = options.query.trim().toLowerCase();
+
+  const results = useMemo(() => {
+    const filtered = data.filter(resource => {
+      if (options.environmentId && resource.environmentId !== options.environmentId) return false;
+      if (options.resourceType && resource.resourceType !== options.resourceType) return false;
+      if (options.status && resource.status !== options.status) return false;
+      if (options.freshness && resource.freshness !== options.freshness) return false;
+      if (normalizedQuery && !resource.searchableText.includes(normalizedQuery)) return false;
+      return true;
+    });
+
+    return filtered.toSorted((left, right) => {
+      if (options.sortBy === 'resourceType') return left.resourceType.localeCompare(right.resourceType) || left.displayName.localeCompare(right.displayName);
+      if (options.sortBy === 'name') return left.displayName.localeCompare(right.displayName);
+      return relevance(right.searchableText, normalizedQuery) - relevance(left.searchableText, normalizedQuery)
+        || left.displayName.localeCompare(right.displayName);
+    });
+  }, [data, normalizedQuery, options.environmentId, options.freshness, options.resourceType, options.sortBy, options.status]);
+
+  return { ...query, data: results };
+}
+
+function relevance(text: string, query: string) {
+  if (!query) return 0;
+  if (text.startsWith(query)) return 3;
+  if (text.includes(` ${query}`)) return 2;
+  return text.includes(query) ? 1 : 0;
+}

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-global-resource-search.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-global-resource-search.ts
@@ -3,12 +3,14 @@ import { useLiveQuery } from '@tanstack/react-db';
 import { resourceIndexCollection } from '../collections';
 import type { GlobalResourceSearchOptions } from '../types/resource-index-read-model';
 
+const MIN_QUERY_LENGTH = 2;
+
 export function useGlobalResourceSearch(options: GlobalResourceSearchOptions) {
   const { data = [], ...query } = useLiveQuery((q) => q.from({ resource: resourceIndexCollection }), []);
   const normalizedQuery = options.query.trim().toLowerCase();
 
   const results = useMemo(() => {
-    if (normalizedQuery.length < 2) {
+    if (normalizedQuery.length < MIN_QUERY_LENGTH) {
       return [];
     }
 

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-global-resource-search.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-global-resource-search.ts
@@ -8,6 +8,10 @@ export function useGlobalResourceSearch(options: GlobalResourceSearchOptions) {
   const normalizedQuery = options.query.trim().toLowerCase();
 
   const results = useMemo(() => {
+    if (normalizedQuery.length < 2) {
+      return [];
+    }
+
     const filtered = data.filter(resource => {
       if (options.environmentId && resource.environmentId !== options.environmentId) return false;
       if (options.resourceType && resource.resourceType !== options.resourceType) return false;
@@ -17,7 +21,7 @@ export function useGlobalResourceSearch(options: GlobalResourceSearchOptions) {
       return true;
     });
 
-    return filtered.toSorted((left, right) => {
+    return [...filtered].sort((left, right) => {
       if (options.sortBy === 'resourceType') return left.resourceType.localeCompare(right.resourceType) || left.displayName.localeCompare(right.displayName);
       if (options.sortBy === 'name') return left.displayName.localeCompare(right.displayName);
       return relevance(right.searchableText, normalizedQuery) - relevance(left.searchableText, normalizedQuery)

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-latest-monitoring-snapshot.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-latest-monitoring-snapshot.ts
@@ -9,9 +9,9 @@ export function useLatestMonitoringSnapshot(environmentId: string | null) {
 
   const latestSnapshot = useMemo(
     () =>
-      data
+      [...data]
         .filter(snapshot => snapshot.environmentId === scopedEnvironmentId)
-        .toSorted((left, right) => Date.parse(right.observedAtUtc) - Date.parse(left.observedAtUtc))[0] ?? null,
+        .sort((left, right) => Date.parse(right.observedAtUtc) - Date.parse(left.observedAtUtc))[0] ?? null,
     [data, scopedEnvironmentId],
   );
 

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-latest-monitoring-snapshot.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-latest-monitoring-snapshot.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from '@tanstack/react-db';
+import { monitoringSnapshotsCollection } from '../collections';
+import { READ_MODEL_UNKNOWN_ENVIRONMENT_ID } from '../types/common';
+
+export function useLatestMonitoringSnapshot(environmentId: string | null) {
+  const { data = [], ...query } = useLiveQuery((q) => q.from({ snapshot: monitoringSnapshotsCollection }), []);
+  const scopedEnvironmentId = environmentId ?? READ_MODEL_UNKNOWN_ENVIRONMENT_ID;
+
+  const latestSnapshot = useMemo(
+    () =>
+      data
+        .filter(snapshot => snapshot.environmentId === scopedEnvironmentId)
+        .toSorted((left, right) => Date.parse(right.observedAtUtc) - Date.parse(left.observedAtUtc))[0] ?? null,
+    [data, scopedEnvironmentId],
+  );
+
+  return { ...query, data: latestSnapshot };
+}

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-monitoring-environment-state.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-monitoring-environment-state.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from '@tanstack/react-db';
+import { monitoringEnvironmentStateCollection } from '../collections';
+
+export function useMonitoringEnvironmentState(environmentId: string | null) {
+  const { data = [], ...query } = useLiveQuery((q) => q.from({ state: monitoringEnvironmentStateCollection }), []);
+
+  const state = useMemo(
+    () => data.find(item => item.environmentId === environmentId) ?? null,
+    [data, environmentId],
+  );
+
+  return { ...query, data: state };
+}

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-recent-monitoring-snapshots.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-recent-monitoring-snapshots.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from '@tanstack/react-db';
+import { monitoringSnapshotsCollection } from '../collections';
+import { READ_MODEL_UNKNOWN_ENVIRONMENT_ID } from '../types/common';
+
+export function useRecentMonitoringSnapshots(environmentId: string | null, limit = 120) {
+  const { data = [], ...query } = useLiveQuery((q) => q.from({ snapshot: monitoringSnapshotsCollection }), []);
+  const scopedEnvironmentId = environmentId ?? READ_MODEL_UNKNOWN_ENVIRONMENT_ID;
+
+  const snapshots = useMemo(
+    () =>
+      data
+        .filter(snapshot => snapshot.environmentId === scopedEnvironmentId)
+        .toSorted((left, right) => Date.parse(right.observedAtUtc) - Date.parse(left.observedAtUtc))
+        .slice(0, limit),
+    [data, limit, scopedEnvironmentId],
+  );
+
+  return { ...query, data: snapshots };
+}

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-recent-monitoring-snapshots.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-recent-monitoring-snapshots.ts
@@ -9,9 +9,9 @@ export function useRecentMonitoringSnapshots(environmentId: string | null, limit
 
   const snapshots = useMemo(
     () =>
-      data
+      [...data]
         .filter(snapshot => snapshot.environmentId === scopedEnvironmentId)
-        .toSorted((left, right) => Date.parse(right.observedAtUtc) - Date.parse(left.observedAtUtc))
+        .sort((left, right) => Date.parse(right.observedAtUtc) - Date.parse(left.observedAtUtc))
         .slice(0, limit),
     [data, limit, scopedEnvironmentId],
   );

--- a/src/NatsManager.Frontend/src/read-model/hooks/use-relationship-map-projection.ts
+++ b/src/NatsManager.Frontend/src/read-model/hooks/use-relationship-map-projection.ts
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from '@tanstack/react-db';
+import { relationshipEdgesCollection, relationshipNodesCollection } from '../collections';
+import type { MapFilter, RelationshipConfidence, RelationshipEdge, ResourceNode } from '../../features/relationships/types';
+
+interface RelationshipMapProjectionOptions {
+  environmentId: string | null;
+  filters?: Partial<MapFilter>;
+}
+
+const confidenceRank: Record<RelationshipConfidence, number> = {
+  Unknown: 0,
+  Low: 1,
+  Medium: 2,
+  High: 3,
+};
+
+export function useRelationshipMapProjection({ environmentId, filters = {} }: RelationshipMapProjectionOptions) {
+  const nodeQuery = useLiveQuery((q) => q.from({ node: relationshipNodesCollection }), []);
+  const edgeQuery = useLiveQuery((q) => q.from({ edge: relationshipEdgesCollection }), []);
+
+  const data = useMemo(() => {
+    const minConfidence = filters.minimumConfidence ?? 'Low';
+    const maxNodes = filters.maxNodes ?? 100;
+    const maxEdges = filters.maxEdges ?? 500;
+
+    const nodes = (nodeQuery.data ?? [])
+      .filter(node => !environmentId || node.environmentId === environmentId)
+      .filter(node => !filters.resourceTypes?.length || filters.resourceTypes.includes(node.resourceType))
+      .filter(node => !filters.healthStates?.length || filters.healthStates.includes(node.healthStatus))
+      .slice(0, maxNodes);
+
+    const nodeIds = new Set(nodes.map(node => node.id));
+    const edges = (edgeQuery.data ?? [])
+      .filter(edge => !environmentId || edge.environmentId === environmentId)
+      .filter(edge => nodeIds.has(edge.sourceNodeId) && nodeIds.has(edge.targetNodeId))
+      .filter(edge => !filters.relationshipTypes?.length || filters.relationshipTypes.includes(edge.relationshipType))
+      .filter(edge => confidenceRank[edge.confidence] >= confidenceRank[minConfidence])
+      .filter(edge => filters.includeInferred ?? true ? true : !edge.inferred)
+      .filter(edge => filters.includeStale ?? true ? true : !edge.stale)
+      .slice(0, maxEdges);
+
+    return {
+      nodes: nodes.map<ResourceNode>(node => ({
+        nodeId: node.id,
+        environmentId: node.environmentId,
+        resourceType: node.resourceType,
+        resourceId: node.resourceId,
+        displayName: node.label,
+        status: node.healthStatus,
+        freshness: node.freshness,
+        isFocal: false,
+        detailRoute: node.detailRoute,
+        metadata: node.metadata,
+      })),
+      edges: edges.map<RelationshipEdge>(edge => ({
+        edgeId: edge.id,
+        environmentId: edge.environmentId,
+        sourceNodeId: edge.sourceNodeId,
+        targetNodeId: edge.targetNodeId,
+        relationshipType: edge.relationshipType,
+        direction: 'Unknown',
+        observationKind: edge.inferred ? 'Inferred' : 'Observed',
+        confidence: edge.confidence,
+        freshness: edge.freshness,
+        status: edge.healthStatus,
+        evidence: edge.evidence,
+      })),
+    };
+  }, [edgeQuery.data, environmentId, filters.healthStates, filters.includeInferred, filters.includeStale, filters.maxEdges, filters.maxNodes, filters.minimumConfidence, filters.relationshipTypes, filters.resourceTypes, nodeQuery.data]);
+
+  return {
+    data,
+    isLoading: nodeQuery.isLoading || edgeQuery.isLoading,
+    isError: nodeQuery.isError || edgeQuery.isError,
+  };
+}

--- a/src/NatsManager.Frontend/src/read-model/projections/dashboard-health.projection.ts
+++ b/src/NatsManager.Frontend/src/read-model/projections/dashboard-health.projection.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { useLatestMonitoringSnapshot } from '../hooks/use-latest-monitoring-snapshot';
+import { useMonitoringEnvironmentState } from '../hooks/use-monitoring-environment-state';
+
+export function useDashboardHealth(environmentId: string | null) {
+  const latest = useLatestMonitoringSnapshot(environmentId);
+  const state = useMonitoringEnvironmentState(environmentId);
+
+  return useMemo(() => ({
+    healthStatus: state.data?.healthStatus ?? latest.data?.healthStatus ?? 'Unknown',
+    connectionStatus: state.data?.connectionStatus ?? latest.data?.connectionStatus ?? 'Disconnected',
+    latestSnapshotAgeMs: null,
+    lastUpdatedUtc: state.data?.lastReceivedAtUtc ?? latest.data?.receivedAtUtc ?? null,
+    errorMessage: state.data?.errorMessage ?? null,
+    isNotConfigured: state.data?.isNotConfigured ?? false,
+  }), [latest.data, state.data]);
+}

--- a/src/NatsManager.Frontend/src/read-model/projections/dashboard-jetstream.projection.ts
+++ b/src/NatsManager.Frontend/src/read-model/projections/dashboard-jetstream.projection.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useLatestMonitoringSnapshot } from '../hooks/use-latest-monitoring-snapshot';
+
+export function useDashboardJetStream(environmentId: string | null) {
+  const latest = useLatestMonitoringSnapshot(environmentId);
+
+  return useMemo(() => ({
+    isEnabled: latest.data?.jetStreamEnabled ?? null,
+    streamCount: latest.data?.streamCount ?? 0,
+    consumerCount: latest.data?.consumerCount ?? 0,
+    totalMessages: latest.data?.totalMessages ?? 0,
+    totalBytes: latest.data?.totalBytes ?? 0,
+  }), [latest.data]);
+}

--- a/src/NatsManager.Frontend/src/read-model/projections/dashboard-traffic.projection.ts
+++ b/src/NatsManager.Frontend/src/read-model/projections/dashboard-traffic.projection.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { useRecentMonitoringSnapshots } from '../hooks/use-recent-monitoring-snapshots';
+
+export function useDashboardTraffic(environmentId: string | null) {
+  const snapshots = useRecentMonitoringSnapshots(environmentId, 120);
+
+  return useMemo(() => {
+    const latest = snapshots.data[0] ?? null;
+    const previous = snapshots.data[1] ?? null;
+
+    return {
+      inMessagesPerSecond: latest?.inMessagesPerSecond ?? 0,
+      outMessagesPerSecond: latest?.outMessagesPerSecond ?? 0,
+      inBytesPerSecond: latest?.inBytesPerSecond ?? 0,
+      outBytesPerSecond: latest?.outBytesPerSecond ?? 0,
+      inMessagesTrend: latest && previous ? latest.inMessagesPerSecond - previous.inMessagesPerSecond : 0,
+      outMessagesTrend: latest && previous ? latest.outMessagesPerSecond - previous.outMessagesPerSecond : 0,
+    };
+  }, [snapshots.data]);
+}

--- a/src/NatsManager.Frontend/src/read-model/projections/index.ts
+++ b/src/NatsManager.Frontend/src/read-model/projections/index.ts
@@ -1,0 +1,3 @@
+export { useDashboardHealth } from './dashboard-health.projection';
+export { useDashboardTraffic } from './dashboard-traffic.projection';
+export { useDashboardJetStream } from './dashboard-jetstream.projection';

--- a/src/NatsManager.Frontend/src/read-model/sync/environment-status-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/environment-status-sync.ts
@@ -10,7 +10,7 @@ export function syncEnvironmentStatus(environment: EnvironmentSource, observedAt
     environmentId: environment.id,
     displayName: environment.name,
     connectionStatus: environment.connectionStatus,
-    freshness: calculateFreshness(environment.lastSuccessfulContact ?? observedAtUtc),
+    freshness: calculateFreshness(environment.lastSuccessfulContact),
     lastSuccessfulInteractionUtc: environment.lastSuccessfulContact,
     lastCheckedAtUtc: observedAtUtc,
     lastErrorMessage: environment.connectionStatus === 'Unavailable' ? 'Environment unavailable' : null,
@@ -26,7 +26,7 @@ export function syncEnvironmentStatus(environment: EnvironmentSource, observedAt
     name: environment.name,
     displayName: environment.name,
     description: environment.description || null,
-    status: environment.connectionStatus === 'Available' ? 'Ok' : environment.connectionStatus === 'Degraded' ? 'Degraded' : environment.connectionStatus === 'Unavailable' ? 'Unavailable' : 'Unknown',
+    status: toEnvironmentHealthStatus(environment.connectionStatus),
     freshness: record.freshness,
     detailRoute: `/environments/${environment.id}`,
     searchableText: [environment.name, environment.description, environment.connectionStatus].filter(Boolean).join(' ').toLowerCase(),
@@ -46,4 +46,11 @@ export function writeSelectedEnvironment(environmentId: string | null, selectedA
     draft.environmentId = environmentId;
     draft.selectedAtUtc = environmentId ? selectedAtUtc : null;
   });
+}
+
+function toEnvironmentHealthStatus(connectionStatus: EnvironmentSource['connectionStatus']) {
+  if (connectionStatus === 'Available') return 'Ok';
+  if (connectionStatus === 'Degraded') return 'Degraded';
+  if (connectionStatus === 'Unavailable') return 'Unavailable';
+  return 'Unknown';
 }

--- a/src/NatsManager.Frontend/src/read-model/sync/environment-status-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/environment-status-sync.ts
@@ -1,0 +1,49 @@
+import { environmentStatusCollection, resourceIndexCollection, selectedEnvironmentCollection } from '../collections';
+import type { EnvironmentDetail, EnvironmentListItem } from '../../features/environments/types';
+import type { EnvironmentStatusRecord } from '../types/environment-read-model';
+import { calculateFreshness, makeEnvironmentScopedId, upsertRecord } from '../utils/collection-utils';
+
+type EnvironmentSource = EnvironmentListItem | EnvironmentDetail;
+
+export function syncEnvironmentStatus(environment: EnvironmentSource, observedAtUtc = new Date().toISOString()) {
+  const record: EnvironmentStatusRecord = {
+    environmentId: environment.id,
+    displayName: environment.name,
+    connectionStatus: environment.connectionStatus,
+    freshness: calculateFreshness(environment.lastSuccessfulContact ?? observedAtUtc),
+    lastSuccessfulInteractionUtc: environment.lastSuccessfulContact,
+    lastCheckedAtUtc: observedAtUtc,
+    lastErrorMessage: environment.connectionStatus === 'Unavailable' ? 'Environment unavailable' : null,
+  };
+
+  upsertRecord(environmentStatusCollection, record.environmentId, record);
+
+  upsertRecord(resourceIndexCollection, makeEnvironmentScopedId(environment.id, 'Environment', environment.id), {
+    id: makeEnvironmentScopedId(environment.id, 'Environment', environment.id),
+    environmentId: environment.id,
+    resourceType: 'Environment',
+    resourceId: environment.id,
+    name: environment.name,
+    displayName: environment.name,
+    description: environment.description || null,
+    status: environment.connectionStatus === 'Available' ? 'Ok' : environment.connectionStatus === 'Degraded' ? 'Degraded' : environment.connectionStatus === 'Unavailable' ? 'Unavailable' : 'Unknown',
+    freshness: record.freshness,
+    detailRoute: `/environments/${environment.id}`,
+    searchableText: [environment.name, environment.description, environment.connectionStatus].filter(Boolean).join(' ').toLowerCase(),
+    lastObservedAtUtc: environment.lastSuccessfulContact,
+    indexedAtUtc: observedAtUtc,
+  });
+}
+
+export function syncEnvironmentStatuses(environments: EnvironmentSource[], observedAtUtc = new Date().toISOString()) {
+  for (const environment of environments) {
+    syncEnvironmentStatus(environment, observedAtUtc);
+  }
+}
+
+export function writeSelectedEnvironment(environmentId: string | null, selectedAtUtc = new Date().toISOString()) {
+  selectedEnvironmentCollection.update('selected-environment', draft => {
+    draft.environmentId = environmentId;
+    draft.selectedAtUtc = environmentId ? selectedAtUtc : null;
+  });
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/environment-status-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/environment-status-sync.ts
@@ -6,11 +6,14 @@ import { calculateFreshness, makeEnvironmentScopedId, upsertRecord } from '../ut
 type EnvironmentSource = EnvironmentListItem | EnvironmentDetail;
 
 export function syncEnvironmentStatus(environment: EnvironmentSource, observedAtUtc = new Date().toISOString()) {
+  const freshness = environment.lastSuccessfulContact
+    ? calculateFreshness(environment.lastSuccessfulContact)
+    : 'Unknown';
   const record: EnvironmentStatusRecord = {
     environmentId: environment.id,
     displayName: environment.name,
     connectionStatus: environment.connectionStatus,
-    freshness: calculateFreshness(environment.lastSuccessfulContact),
+    freshness,
     lastSuccessfulInteractionUtc: environment.lastSuccessfulContact,
     lastCheckedAtUtc: observedAtUtc,
     lastErrorMessage: environment.connectionStatus === 'Unavailable' ? 'Environment unavailable' : null,

--- a/src/NatsManager.Frontend/src/read-model/sync/jetstream-query-sync.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/jetstream-query-sync.test.ts
@@ -1,0 +1,53 @@
+import { consumersCollection, resourceIndexCollection, streamsCollection } from '../collections';
+import { syncConsumer, syncStream } from './jetstream-query-sync';
+
+describe('JetStream read-model sync', () => {
+  beforeEach(() => {
+    clearCollection(streamsCollection, record => record.id);
+    clearCollection(consumersCollection, record => record.id);
+    clearCollection(resourceIndexCollection, record => record.id);
+  });
+
+  it('reconciles stream and consumer metadata from backend-confirmed data', () => {
+    syncStream('env-1', {
+      name: 'ORDERS',
+      description: 'Order events',
+      subjects: ['orders.*'],
+      retentionPolicy: 'Limits',
+      storageType: 'File',
+      messages: 10,
+      bytes: 1024,
+      consumerCount: 1,
+      created: '2026-01-01T00:00:00.000Z',
+    });
+    syncConsumer('env-1', 'ORDERS', {
+      streamName: 'ORDERS',
+      name: 'worker',
+      description: null,
+      deliverPolicy: 'All',
+      ackPolicy: 'Explicit',
+      filterSubject: null,
+      numPending: 5,
+      numAckPending: 0,
+      numRedelivered: 0,
+      isHealthy: true,
+      created: '2026-01-01T00:00:00.000Z',
+      state: {
+        delivered: 10,
+        ackFloor: 5,
+        numPending: 5,
+        numAckPending: 0,
+        numRedelivered: 0,
+      },
+    });
+
+    expect(streamsCollection.get('env-1:Stream:ORDERS')?.messages).toBe(10);
+    expect(consumersCollection.get('env-1:Consumer:ORDERS:worker')?.pendingMessages).toBe(5);
+    expect(resourceIndexCollection.get('env-1:Consumer:ORDERS:worker')?.resourceType).toBe('Consumer');
+  });
+});
+
+function clearCollection<T extends object>(collection: { toArray: T[]; delete: (keys: string[]) => unknown }, getKey: (record: T) => string) {
+  const ids = collection.toArray.map(getKey);
+  if (ids.length > 0) collection.delete(ids);
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/jetstream-query-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/jetstream-query-sync.ts
@@ -1,0 +1,92 @@
+import { consumersCollection, resourceIndexCollection, streamsCollection } from '../collections';
+import type { ConsumerInfo, StreamDetail, StreamInfo, StreamListItem } from '../../features/jetstream/types';
+import type { ConsumerRecord, StreamRecord } from '../types/jetstream-read-model';
+import { makeEnvironmentScopedId, upsertRecord } from '../utils/collection-utils';
+
+export function syncStreams(environmentId: string, streams: StreamListItem[], observedAtUtc = new Date().toISOString()) {
+  for (const stream of streams) {
+    syncStream(environmentId, stream, observedAtUtc);
+  }
+}
+
+export function syncStreamDetail(environmentId: string, detail: StreamDetail, observedAtUtc = new Date().toISOString()) {
+  syncStream(environmentId, detail.info, observedAtUtc, detail.config.replicas);
+  syncConsumers(environmentId, detail.info.name, detail.consumers, observedAtUtc);
+}
+
+export function syncStream(environmentId: string, stream: StreamListItem | StreamInfo, observedAtUtc = new Date().toISOString(), replicas: number | null = null) {
+  const record: StreamRecord = {
+    id: makeEnvironmentScopedId(environmentId, 'Stream', stream.name),
+    environmentId,
+    name: stream.name,
+    description: stream.description || null,
+    subjects: stream.subjects,
+    retentionPolicy: stream.retentionPolicy,
+    storage: stream.storageType,
+    replicas,
+    messages: stream.messages,
+    bytes: stream.bytes,
+    consumerCount: stream.consumerCount,
+    healthStatus: 'Ok',
+    lastObservedAtUtc: observedAtUtc,
+  };
+
+  upsertRecord(streamsCollection, record.id, record);
+  upsertRecord(resourceIndexCollection, record.id, {
+    id: record.id,
+    environmentId,
+    resourceType: 'Stream',
+    resourceId: record.name,
+    name: record.name,
+    displayName: record.name,
+    description: record.description,
+    status: record.healthStatus,
+    freshness: 'Live',
+    detailRoute: `/environments/${environmentId}/jetstream/streams/${encodeURIComponent(record.name)}`,
+    searchableText: [record.name, record.description, ...record.subjects, 'stream'].filter(Boolean).join(' ').toLowerCase(),
+    lastObservedAtUtc: observedAtUtc,
+    indexedAtUtc: observedAtUtc,
+  });
+}
+
+export function syncConsumers(environmentId: string, streamName: string, consumers: ConsumerInfo[], observedAtUtc = new Date().toISOString()) {
+  for (const consumer of consumers) {
+    syncConsumer(environmentId, streamName, consumer, observedAtUtc);
+  }
+}
+
+export function syncConsumer(environmentId: string, streamName: string, consumer: ConsumerInfo, observedAtUtc = new Date().toISOString()) {
+  const record: ConsumerRecord = {
+    id: makeEnvironmentScopedId(environmentId, 'Consumer', streamName, consumer.name),
+    environmentId,
+    streamName,
+    name: consumer.name,
+    description: consumer.description,
+    durableName: consumer.name,
+    deliverPolicy: consumer.deliverPolicy,
+    ackPolicy: consumer.ackPolicy,
+    pendingMessages: consumer.numPending,
+    redeliveredMessages: consumer.numRedelivered,
+    ackFloorConsumerSequence: consumer.state.ackFloor,
+    ackFloorStreamSequence: null,
+    healthStatus: consumer.isHealthy ? 'Ok' : 'Degraded',
+    lastObservedAtUtc: observedAtUtc,
+  };
+
+  upsertRecord(consumersCollection, record.id, record);
+  upsertRecord(resourceIndexCollection, record.id, {
+    id: record.id,
+    environmentId,
+    resourceType: 'Consumer',
+    resourceId: `${streamName}/${consumer.name}`,
+    name: consumer.name,
+    displayName: consumer.name,
+    description: consumer.description,
+    status: record.healthStatus,
+    freshness: 'Live',
+    detailRoute: `/environments/${environmentId}/jetstream/streams/${encodeURIComponent(streamName)}/consumers/${encodeURIComponent(consumer.name)}`,
+    searchableText: [consumer.name, consumer.description, streamName, 'consumer'].filter(Boolean).join(' ').toLowerCase(),
+    lastObservedAtUtc: observedAtUtc,
+    indexedAtUtc: observedAtUtc,
+  });
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/monitoring-hub-sync.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/monitoring-hub-sync.test.ts
@@ -1,0 +1,69 @@
+import { monitoringEnvironmentStateCollection, monitoringSnapshotsCollection } from '../collections';
+import type { MonitoringSnapshot } from '../../features/monitoring/types';
+import { writeMonitoringSnapshot } from './monitoring-hub-sync';
+
+describe('monitoring read-model sync', () => {
+  beforeEach(() => {
+    clearMonitoringCollections();
+  });
+
+  it('upserts duplicate snapshots', () => {
+    const snapshot = createSnapshot({ environmentId: 'env-1', timestamp: '2026-01-01T00:00:00.000Z' });
+
+    writeMonitoringSnapshot(snapshot);
+    writeMonitoringSnapshot({ ...snapshot, server: { ...snapshot.server, connections: 42 } });
+
+    const records = monitoringSnapshotsCollection.toArray.filter(record => record.environmentId === 'env-1');
+    expect(records).toHaveLength(1);
+    expect(records[0]?.connections).toBe(42);
+  });
+
+  it('trims snapshots per environment without leaking between environments', () => {
+    for (let index = 0; index < 121; index += 1) {
+      writeMonitoringSnapshot(createSnapshot({
+        environmentId: 'env-1',
+        timestamp: new Date(Date.parse('2026-01-01T00:00:00.000Z') + index * 1000).toISOString(),
+      }));
+    }
+    writeMonitoringSnapshot(createSnapshot({ environmentId: 'env-2', timestamp: '2026-01-01T00:00:00.000Z' }));
+
+    expect(monitoringSnapshotsCollection.toArray.filter(record => record.environmentId === 'env-1')).toHaveLength(120);
+    expect(monitoringSnapshotsCollection.toArray.filter(record => record.environmentId === 'env-2')).toHaveLength(1);
+    expect(monitoringEnvironmentStateCollection.get('env-1')?.latestSnapshotId).toBe('env-1:2026-01-01T00:02:00.000Z');
+  });
+});
+
+function clearMonitoringCollections() {
+  const snapshotIds = monitoringSnapshotsCollection.toArray.map(record => record.id);
+  if (snapshotIds.length > 0) monitoringSnapshotsCollection.delete(snapshotIds);
+
+  const stateIds = monitoringEnvironmentStateCollection.toArray.map(record => record.environmentId);
+  if (stateIds.length > 0) monitoringEnvironmentStateCollection.delete(stateIds);
+}
+
+function createSnapshot(overrides: Partial<MonitoringSnapshot> = {}): MonitoringSnapshot {
+  return {
+    environmentId: overrides.environmentId ?? 'env-1',
+    timestamp: overrides.timestamp ?? '2026-01-01T00:00:00.000Z',
+    server: {
+      version: '2.10.0',
+      connections: 1,
+      totalConnections: 1,
+      maxConnections: 100,
+      inMsgsTotal: 0,
+      outMsgsTotal: 0,
+      inBytesTotal: 0,
+      outBytesTotal: 0,
+      inMsgsPerSec: 0,
+      outMsgsPerSec: 0,
+      inBytesPerSec: 0,
+      outBytesPerSec: 0,
+      uptimeSeconds: 0,
+      memoryBytes: 0,
+    },
+    jetStream: null,
+    status: 'Ok',
+    healthStatus: 'Ok',
+    ...overrides,
+  };
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/monitoring-hub-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/monitoring-hub-sync.ts
@@ -1,0 +1,160 @@
+import { monitoringEnvironmentStateCollection, monitoringSnapshotsCollection, resourceIndexCollection } from '../collections';
+import type { MonitoringSnapshot } from '../../features/monitoring/types';
+import type { MonitoringSnapshotRecord } from '../types/monitoring-read-model';
+import type { HealthStatus, ReadModelConnectionStatus } from '../types/common';
+import { makeEnvironmentScopedId, trimCollectionByEnvironment, upsertRecord } from '../utils/collection-utils';
+
+export const MAX_MONITORING_SNAPSHOTS_PER_ENVIRONMENT = 120;
+
+export function toMonitoringSnapshotRecord(
+  snapshot: MonitoringSnapshot,
+  connectionStatus: ReadModelConnectionStatus,
+  receivedAtUtc = new Date().toISOString(),
+): MonitoringSnapshotRecord {
+  const observedAtUtc = snapshot.timestamp;
+  const healthStatus = normalizeHealthStatus(snapshot.healthStatus);
+
+  return {
+    id: getMonitoringSnapshotId(snapshot.environmentId, observedAtUtc),
+    environmentId: snapshot.environmentId,
+    observedAtUtc,
+    receivedAtUtc,
+    healthStatus,
+    status: snapshot.status,
+    connectionStatus,
+    serverVersion: snapshot.server.version,
+    connections: snapshot.server.connections,
+    totalConnections: snapshot.server.totalConnections,
+    maxConnections: snapshot.server.maxConnections,
+    subscriptions: null,
+    inMessagesPerSecond: snapshot.server.inMsgsPerSec,
+    outMessagesPerSecond: snapshot.server.outMsgsPerSec,
+    inBytesPerSecond: snapshot.server.inBytesPerSec,
+    outBytesPerSecond: snapshot.server.outBytesPerSec,
+    inMessagesTotal: snapshot.server.inMsgsTotal,
+    outMessagesTotal: snapshot.server.outMsgsTotal,
+    inBytesTotal: snapshot.server.inBytesTotal,
+    outBytesTotal: snapshot.server.outBytesTotal,
+    memoryBytes: snapshot.server.memoryBytes,
+    cpuPercentage: null,
+    uptimeSeconds: snapshot.server.uptimeSeconds,
+    jetStreamEnabled: snapshot.jetStream !== null,
+    streamCount: snapshot.jetStream?.streamCount ?? null,
+    consumerCount: snapshot.jetStream?.consumerCount ?? null,
+    totalMessages: snapshot.jetStream?.totalMessages ?? null,
+    totalBytes: snapshot.jetStream?.totalBytes ?? null,
+  };
+}
+
+export function toMonitoringSnapshot(record: MonitoringSnapshotRecord): MonitoringSnapshot {
+  return {
+    environmentId: record.environmentId,
+    timestamp: record.observedAtUtc,
+    server: {
+      version: record.serverVersion ?? '',
+      connections: record.connections,
+      totalConnections: record.totalConnections,
+      maxConnections: record.maxConnections,
+      inMsgsTotal: record.inMessagesTotal,
+      outMsgsTotal: record.outMessagesTotal,
+      inBytesTotal: record.inBytesTotal,
+      outBytesTotal: record.outBytesTotal,
+      inMsgsPerSec: record.inMessagesPerSecond,
+      outMsgsPerSec: record.outMessagesPerSecond,
+      inBytesPerSec: record.inBytesPerSecond,
+      outBytesPerSec: record.outBytesPerSecond,
+      uptimeSeconds: record.uptimeSeconds ?? 0,
+      memoryBytes: record.memoryBytes ?? 0,
+    },
+    jetStream: record.jetStreamEnabled
+      ? {
+          streamCount: record.streamCount ?? 0,
+          consumerCount: record.consumerCount ?? 0,
+          totalMessages: record.totalMessages ?? 0,
+          totalBytes: record.totalBytes ?? 0,
+        }
+      : null,
+    status: record.status,
+    healthStatus: record.healthStatus === 'Unknown' ? 'Unavailable' : record.healthStatus,
+  };
+}
+
+export function writeMonitoringSnapshot(
+  snapshot: MonitoringSnapshot,
+  connectionStatus: ReadModelConnectionStatus = 'Connected',
+  receivedAtUtc = new Date().toISOString(),
+) {
+  const record = toMonitoringSnapshotRecord(snapshot, connectionStatus, receivedAtUtc);
+  upsertRecord(monitoringSnapshotsCollection, record.id, record);
+  trimCollectionByEnvironment<MonitoringSnapshotRecord>(
+    monitoringSnapshotsCollection,
+    record.environmentId,
+    MAX_MONITORING_SNAPSHOTS_PER_ENVIRONMENT,
+    item => item.observedAtUtc,
+    item => item.id,
+  );
+
+  upsertRecord(monitoringEnvironmentStateCollection, record.environmentId, {
+    environmentId: record.environmentId,
+    connectionStatus,
+    healthStatus: record.healthStatus,
+    latestSnapshotId: record.id,
+    lastReceivedAtUtc: record.receivedAtUtc,
+    staleSinceUtc: null,
+    errorMessage: null,
+    isNotConfigured: false,
+  });
+
+  upsertRecord(resourceIndexCollection, makeEnvironmentScopedId(record.environmentId, 'Server', record.serverVersion ?? 'server'), {
+    id: makeEnvironmentScopedId(record.environmentId, 'Server', record.serverVersion ?? 'server'),
+    environmentId: record.environmentId,
+    resourceType: 'Server',
+    resourceId: record.serverVersion ?? 'server',
+    name: record.serverVersion ?? 'Server',
+    displayName: record.serverVersion ? `NATS ${record.serverVersion}` : 'NATS Server',
+    description: `${record.connections} active connections`,
+    status: record.healthStatus,
+    freshness: 'Live',
+    detailRoute: `/environments/${record.environmentId}/monitoring`,
+    searchableText: ['server', 'monitoring', record.serverVersion, record.healthStatus].filter(Boolean).join(' ').toLowerCase(),
+    lastObservedAtUtc: record.observedAtUtc,
+    indexedAtUtc: receivedAtUtc,
+  });
+}
+
+export function writeMonitoringHistory(environmentId: string, snapshots: MonitoringSnapshot[]) {
+  for (const snapshot of snapshots) {
+    writeMonitoringSnapshot(snapshot, 'Connected', snapshot.timestamp);
+  }
+
+  if (snapshots.length === 0) {
+    writeMonitoringState(environmentId, 'Connected', null, false);
+  }
+}
+
+export function writeMonitoringState(
+  environmentId: string,
+  connectionStatus: ReadModelConnectionStatus,
+  errorMessage: string | null,
+  isNotConfigured: boolean,
+) {
+  const existing = monitoringEnvironmentStateCollection.get(environmentId);
+  upsertRecord(monitoringEnvironmentStateCollection, environmentId, {
+    environmentId,
+    connectionStatus,
+    healthStatus: existing?.healthStatus ?? (isNotConfigured ? 'Unavailable' : 'Unknown'),
+    latestSnapshotId: existing?.latestSnapshotId ?? null,
+    lastReceivedAtUtc: existing?.lastReceivedAtUtc ?? null,
+    staleSinceUtc: connectionStatus === 'Disconnected' ? new Date().toISOString() : null,
+    errorMessage,
+    isNotConfigured,
+  });
+}
+
+export function getMonitoringSnapshotId(environmentId: string, observedAtUtc: string) {
+  return makeEnvironmentScopedId(environmentId, observedAtUtc);
+}
+
+function normalizeHealthStatus(status: MonitoringSnapshot['healthStatus']): HealthStatus {
+  return status;
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.test.ts
@@ -1,0 +1,107 @@
+import { relationshipEdgesCollection, relationshipEvidenceCollection, relationshipNodesCollection } from '../collections';
+import type { RelationshipMap } from '../../features/relationships/types';
+import { syncRelationshipMap } from './relationship-map-sync';
+
+describe('relationship map read-model sync', () => {
+  beforeEach(() => {
+    clearCollection(relationshipNodesCollection, record => record.id);
+    clearCollection(relationshipEdgesCollection, record => record.id);
+    clearCollection(relationshipEvidenceCollection, record => record.id);
+  });
+
+  it('stores nodes, edges, and evidence together', () => {
+    syncRelationshipMap(createMap());
+
+    expect(relationshipNodesCollection.get('stream-orders')?.label).toBe('ORDERS');
+    expect(relationshipEdgesCollection.get('edge-1')?.sourceNodeId).toBe('consumer-worker');
+    expect(relationshipEvidenceCollection.get('edge-1:0')?.summary).toBe('consumer reads stream');
+  });
+});
+
+function createMap(): RelationshipMap {
+  return {
+    environmentId: 'env-1',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    depth: 1,
+    focalResource: {
+      environmentId: 'env-1',
+      resourceType: 'Stream',
+      resourceId: 'ORDERS',
+      displayName: 'ORDERS',
+      route: null,
+    },
+    filters: {
+      depth: 1,
+      resourceTypes: null,
+      relationshipTypes: null,
+      healthStates: null,
+      minimumConfidence: 'Low',
+      includeInferred: true,
+      includeStale: true,
+      maxNodes: 100,
+      maxEdges: 500,
+    },
+    omittedCounts: {
+      filteredNodes: 0,
+      filteredEdges: 0,
+      collapsedNodes: 0,
+      collapsedEdges: 0,
+      unsafeRelationships: 0,
+    },
+    nodes: [
+      {
+        nodeId: 'stream-orders',
+        environmentId: 'env-1',
+        resourceType: 'Stream',
+        resourceId: 'ORDERS',
+        displayName: 'ORDERS',
+        status: 'Healthy',
+        freshness: 'Live',
+        isFocal: true,
+        detailRoute: null,
+        metadata: {},
+      },
+      {
+        nodeId: 'consumer-worker',
+        environmentId: 'env-1',
+        resourceType: 'Consumer',
+        resourceId: 'worker',
+        displayName: 'worker',
+        status: 'Healthy',
+        freshness: 'Live',
+        isFocal: false,
+        detailRoute: null,
+        metadata: {},
+      },
+    ],
+    edges: [
+      {
+        edgeId: 'edge-1',
+        environmentId: 'env-1',
+        sourceNodeId: 'consumer-worker',
+        targetNodeId: 'stream-orders',
+        relationshipType: 'ConsumesFrom',
+        direction: 'Outbound',
+        observationKind: 'Observed',
+        confidence: 'High',
+        freshness: 'Live',
+        status: 'Healthy',
+        evidence: [
+          {
+            sourceModule: 'JetStream',
+            evidenceType: 'ConsumerInfo',
+            observedAt: '2026-01-01T00:00:00.000Z',
+            freshness: 'Live',
+            summary: 'consumer reads stream',
+            safeFields: {},
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function clearCollection<T extends object>(collection: { toArray: T[]; delete: (keys: string[]) => unknown }, getKey: (record: T) => string) {
+  const ids = collection.toArray.map(getKey);
+  if (ids.length > 0) collection.delete(ids);
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.test.ts
@@ -16,6 +16,34 @@ describe('relationship map read-model sync', () => {
     expect(relationshipEdgesCollection.get('edge-1')?.sourceNodeId).toBe('consumer-worker');
     expect(relationshipEvidenceCollection.get('edge-1:0')?.summary).toBe('consumer reads stream');
   });
+
+  it('removes stale evidence records when an edge is resynced with fewer evidence items', () => {
+    const map = createMap();
+    syncRelationshipMap({
+      ...map,
+      edges: [
+        {
+          ...map.edges[0],
+          evidence: [
+            ...map.edges[0].evidence,
+            {
+              sourceModule: 'Search',
+              evidenceType: 'SearchResult',
+              observedAt: '2026-01-01T00:00:01.000Z',
+              freshness: 'Live',
+              summary: 'search corroborates stream usage',
+              safeFields: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    syncRelationshipMap(map);
+
+    expect(relationshipEvidenceCollection.get('edge-1:0')?.summary).toBe('consumer reads stream');
+    expect(relationshipEvidenceCollection.get('edge-1:1')).toBeUndefined();
+  });
 });
 
 function createMap(): RelationshipMap {

--- a/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.ts
@@ -1,0 +1,76 @@
+import { relationshipEdgesCollection, relationshipEvidenceCollection, relationshipNodesCollection, resourceIndexCollection } from '../collections';
+import type { RelationshipMap, RelationshipEvidence, ResourceHealthStatus } from '../../features/relationships/types';
+import type { HealthStatus } from '../types/common';
+import { makeEnvironmentScopedId, upsertRecord } from '../utils/collection-utils';
+
+export function syncRelationshipMap(map: RelationshipMap) {
+  for (const node of map.nodes) {
+    upsertRecord(relationshipNodesCollection, node.nodeId, {
+      id: node.nodeId,
+      environmentId: node.environmentId,
+      resourceType: node.resourceType,
+      resourceId: node.resourceId,
+      label: node.displayName,
+      healthStatus: node.status,
+      freshness: node.freshness,
+      detailRoute: node.detailRoute,
+      lastObservedAtUtc: map.generatedAt,
+      metadata: node.metadata,
+    });
+
+    upsertRecord(resourceIndexCollection, makeEnvironmentScopedId(node.environmentId, node.resourceType, node.resourceId), {
+      id: makeEnvironmentScopedId(node.environmentId, node.resourceType, node.resourceId),
+      environmentId: node.environmentId,
+      resourceType: node.resourceType === 'ObjectStoreObject' ? 'ObjectStoreObject' : node.resourceType,
+      resourceId: node.resourceId,
+      name: node.displayName,
+      displayName: node.displayName,
+      description: null,
+      status: toHealthStatus(node.status),
+      freshness: node.freshness === 'Live' ? 'Live' : node.freshness === 'Stale' ? 'Stale' : 'Unknown',
+      detailRoute: node.detailRoute,
+      searchableText: [node.displayName, node.resourceType, node.resourceId].join(' ').toLowerCase(),
+      lastObservedAtUtc: map.generatedAt,
+      indexedAtUtc: map.generatedAt,
+    });
+  }
+
+  for (const edge of map.edges) {
+    upsertRecord(relationshipEdgesCollection, edge.edgeId, {
+      id: edge.edgeId,
+      environmentId: edge.environmentId,
+      sourceNodeId: edge.sourceNodeId,
+      targetNodeId: edge.targetNodeId,
+      relationshipType: edge.relationshipType,
+      confidence: edge.confidence,
+      inferred: edge.observationKind === 'Inferred',
+      stale: edge.freshness === 'Stale',
+      healthStatus: edge.status,
+      freshness: edge.freshness,
+      evidence: edge.evidence,
+      lastObservedAtUtc: map.generatedAt,
+    });
+
+    edge.evidence.forEach((evidence, index) => {
+      upsertRecord(relationshipEvidenceCollection, `${edge.edgeId}:${index}`, toEvidenceRecord(edge.environmentId, edge.edgeId, evidence, index));
+    });
+  }
+}
+
+function toEvidenceRecord(environmentId: string, edgeId: string, evidence: RelationshipEvidence, index: number) {
+  return {
+    id: `${edgeId}:${index}`,
+    environmentId,
+    edgeId,
+    evidenceType: evidence.evidenceType,
+    summary: evidence.summary,
+    observedAtUtc: evidence.observedAt,
+  };
+}
+
+function toHealthStatus(status: ResourceHealthStatus): HealthStatus {
+  if (status === 'Healthy') return 'Ok';
+  if (status === 'Warning' || status === 'Degraded' || status === 'Stale') return 'Degraded';
+  if (status === 'Unavailable') return 'Unavailable';
+  return 'Unknown';
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/relationship-map-sync.ts
@@ -2,9 +2,13 @@ import { relationshipEdgesCollection, relationshipEvidenceCollection, relationsh
 import type { RelationshipMap, RelationshipEvidence, ResourceHealthStatus } from '../../features/relationships/types';
 import type { HealthStatus } from '../types/common';
 import { makeEnvironmentScopedId, upsertRecord } from '../utils/collection-utils';
+import { normalizeResourceIndexType } from './resource-query-sync';
 
 export function syncRelationshipMap(map: RelationshipMap) {
   for (const node of map.nodes) {
+    const resourceType = normalizeResourceIndexType(node.resourceType);
+    const resourceIndexId = makeEnvironmentScopedId(node.environmentId, resourceType, node.resourceId);
+
     upsertRecord(relationshipNodesCollection, node.nodeId, {
       id: node.nodeId,
       environmentId: node.environmentId,
@@ -18,16 +22,16 @@ export function syncRelationshipMap(map: RelationshipMap) {
       metadata: node.metadata,
     });
 
-    upsertRecord(resourceIndexCollection, makeEnvironmentScopedId(node.environmentId, node.resourceType, node.resourceId), {
-      id: makeEnvironmentScopedId(node.environmentId, node.resourceType, node.resourceId),
+    upsertRecord(resourceIndexCollection, resourceIndexId, {
+      id: resourceIndexId,
       environmentId: node.environmentId,
-      resourceType: node.resourceType === 'ObjectStoreObject' ? 'ObjectStoreObject' : node.resourceType,
+      resourceType,
       resourceId: node.resourceId,
       name: node.displayName,
       displayName: node.displayName,
       description: null,
       status: toHealthStatus(node.status),
-      freshness: node.freshness === 'Live' ? 'Live' : node.freshness === 'Stale' ? 'Stale' : 'Unknown',
+      freshness: toRelationshipFreshness(node.freshness),
       detailRoute: node.detailRoute,
       searchableText: [node.displayName, node.resourceType, node.resourceId].join(' ').toLowerCase(),
       lastObservedAtUtc: map.generatedAt,
@@ -51,6 +55,7 @@ export function syncRelationshipMap(map: RelationshipMap) {
       lastObservedAtUtc: map.generatedAt,
     });
 
+    deleteEdgeEvidence(edge.edgeId);
     edge.evidence.forEach((evidence, index) => {
       upsertRecord(relationshipEvidenceCollection, `${edge.edgeId}:${index}`, toEvidenceRecord(edge.environmentId, edge.edgeId, evidence, index));
     });
@@ -73,4 +78,20 @@ function toHealthStatus(status: ResourceHealthStatus): HealthStatus {
   if (status === 'Warning' || status === 'Degraded' || status === 'Stale') return 'Degraded';
   if (status === 'Unavailable') return 'Unavailable';
   return 'Unknown';
+}
+
+function toRelationshipFreshness(freshness: RelationshipMap['nodes'][number]['freshness']) {
+  if (freshness === 'Live') return 'Live';
+  if (freshness === 'Stale') return 'Stale';
+  return 'Unknown';
+}
+
+function deleteEdgeEvidence(edgeId: string) {
+  const evidenceIds = relationshipEvidenceCollection.toArray
+    .filter(record => record.edgeId === edgeId)
+    .map(record => record.id);
+
+  if (evidenceIds.length > 0) {
+    relationshipEvidenceCollection.delete(evidenceIds);
+  }
 }

--- a/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.test.ts
@@ -1,0 +1,26 @@
+import { resourceIndexCollection } from '../collections';
+import { syncSearchResults } from './resource-query-sync';
+
+describe('resource index sync', () => {
+  beforeEach(() => {
+    const ids = resourceIndexCollection.toArray.map(record => record.id);
+    if (ids.length > 0) resourceIndexCollection.delete(ids);
+  });
+
+  it('indexes server search results for local lookup', () => {
+    syncSearchResults([
+      {
+        resourceType: 'Stream',
+        resourceId: 'ORDERS',
+        displayName: 'ORDERS',
+        environmentId: 'env-1',
+        environmentName: 'Local',
+        description: 'Order events',
+      },
+    ], '2026-01-01T00:00:00.000Z');
+
+    const record = resourceIndexCollection.get('env-1:Stream:ORDERS');
+    expect(record?.searchableText).toContain('order events');
+    expect(record?.resourceType).toBe('Stream');
+  });
+});

--- a/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.test.ts
@@ -23,4 +23,18 @@ describe('resource index sync', () => {
     expect(record?.searchableText).toContain('order events');
     expect(record?.resourceType).toBe('Stream');
   });
+
+  it('normalizes object-store search result types to keep existing navigation behavior', () => {
+    syncSearchResults([
+      {
+        resourceType: 'ObjectStoreObject',
+        resourceId: 'orders-bucket/incoming/orders/1.json',
+        displayName: 'orders/1.json',
+        environmentId: 'env-1',
+      },
+    ], '2026-01-01T00:00:00.000Z');
+
+    const record = resourceIndexCollection.get('env-1:ObjectItem:orders-bucket/incoming/orders/1.json');
+    expect(record?.resourceType).toBe('ObjectItem');
+  });
 });

--- a/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.ts
@@ -1,0 +1,55 @@
+import { resourceIndexCollection } from '../collections';
+import type { SearchResult } from '../../features/search/types';
+import { makeEnvironmentScopedId, upsertRecord } from '../utils/collection-utils';
+import type { ResourceIndexType } from '../types/resource-index-read-model';
+
+export function syncSearchResults(results: SearchResult[], indexedAtUtc = new Date().toISOString()) {
+  for (const result of results) {
+    const environmentId = result.environmentId ?? 'global';
+    const resourceType = toResourceIndexType(result.resourceType);
+    const id = makeEnvironmentScopedId(environmentId, resourceType, result.resourceId);
+
+    upsertRecord(resourceIndexCollection, id, {
+      id,
+      environmentId,
+      resourceType,
+      resourceId: result.resourceId,
+      name: result.displayName,
+      displayName: result.displayName,
+      description: result.description ?? null,
+      status: 'Unknown',
+      freshness: 'Unknown',
+      detailRoute: null,
+      searchableText: [result.displayName, result.description, result.resourceType, result.environmentName].filter(Boolean).join(' ').toLowerCase(),
+      lastObservedAtUtc: null,
+      indexedAtUtc,
+    });
+  }
+}
+
+function toResourceIndexType(resourceType: string): ResourceIndexType {
+  const knownTypes = new Set<ResourceIndexType>([
+    'Environment',
+    'Server',
+    'Connection',
+    'Subject',
+    'Stream',
+    'Consumer',
+    'KvBucket',
+    'KvKey',
+    'ObjectBucket',
+    'Object',
+    'ObjectStoreObject',
+    'Service',
+    'Endpoint',
+    'ServiceEndpoint',
+    'Alert',
+    'Event',
+    'External',
+    'JetStreamAccount',
+    'Client',
+    'RelationshipNode',
+  ]);
+
+  return knownTypes.has(resourceType as ResourceIndexType) ? resourceType as ResourceIndexType : 'External';
+}

--- a/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.ts
+++ b/src/NatsManager.Frontend/src/read-model/sync/resource-query-sync.ts
@@ -3,10 +3,38 @@ import type { SearchResult } from '../../features/search/types';
 import { makeEnvironmentScopedId, upsertRecord } from '../utils/collection-utils';
 import type { ResourceIndexType } from '../types/resource-index-read-model';
 
+const RESOURCE_TYPE_ALIASES: Record<string, ResourceIndexType> = {
+  ObjectStoreObject: 'ObjectItem',
+};
+
+const KNOWN_RESOURCE_TYPES = new Set<ResourceIndexType>([
+  'Environment',
+  'Server',
+  'Connection',
+  'Subject',
+  'Stream',
+  'Consumer',
+  'KvBucket',
+  'KvKey',
+  'ObjectBucket',
+  'Object',
+  'ObjectItem',
+  'ObjectStoreObject',
+  'Service',
+  'Endpoint',
+  'ServiceEndpoint',
+  'Alert',
+  'Event',
+  'External',
+  'JetStreamAccount',
+  'Client',
+  'RelationshipNode',
+]);
+
 export function syncSearchResults(results: SearchResult[], indexedAtUtc = new Date().toISOString()) {
   for (const result of results) {
     const environmentId = result.environmentId ?? 'global';
-    const resourceType = toResourceIndexType(result.resourceType);
+    const resourceType = normalizeResourceIndexType(result.resourceType);
     const id = makeEnvironmentScopedId(environmentId, resourceType, result.resourceId);
 
     upsertRecord(resourceIndexCollection, id, {
@@ -27,29 +55,7 @@ export function syncSearchResults(results: SearchResult[], indexedAtUtc = new Da
   }
 }
 
-function toResourceIndexType(resourceType: string): ResourceIndexType {
-  const knownTypes = new Set<ResourceIndexType>([
-    'Environment',
-    'Server',
-    'Connection',
-    'Subject',
-    'Stream',
-    'Consumer',
-    'KvBucket',
-    'KvKey',
-    'ObjectBucket',
-    'Object',
-    'ObjectStoreObject',
-    'Service',
-    'Endpoint',
-    'ServiceEndpoint',
-    'Alert',
-    'Event',
-    'External',
-    'JetStreamAccount',
-    'Client',
-    'RelationshipNode',
-  ]);
-
-  return knownTypes.has(resourceType as ResourceIndexType) ? resourceType as ResourceIndexType : 'External';
+export function normalizeResourceIndexType(resourceType: string): ResourceIndexType {
+  const normalizedType = RESOURCE_TYPE_ALIASES[resourceType] ?? resourceType;
+  return KNOWN_RESOURCE_TYPES.has(normalizedType as ResourceIndexType) ? normalizedType as ResourceIndexType : 'External';
 }

--- a/src/NatsManager.Frontend/src/read-model/types/common.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/common.ts
@@ -1,0 +1,16 @@
+export type HealthStatus = 'Ok' | 'Degraded' | 'Unavailable' | 'Unknown';
+export type Freshness = 'Live' | 'Recent' | 'Stale' | 'Unknown';
+export type ReadModelConnectionStatus = 'Connected' | 'Connecting' | 'Disconnected' | 'Reconnecting';
+
+export interface FreshnessFields {
+  observedAtUtc: string | null;
+  receivedAtUtc: string | null;
+  freshness: Freshness;
+}
+
+export const FRESHNESS_THRESHOLDS = {
+  liveMs: 10_000,
+  recentMs: 60_000,
+} as const;
+
+export const READ_MODEL_UNKNOWN_ENVIRONMENT_ID = '__no-environment__';

--- a/src/NatsManager.Frontend/src/read-model/types/environment-read-model.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/environment-read-model.ts
@@ -1,0 +1,19 @@
+import type { Freshness } from './common';
+
+export type EnvironmentConnectionStatus = 'Available' | 'Unavailable' | 'Unknown' | 'Checking' | 'Degraded';
+
+export interface EnvironmentStatusRecord {
+  environmentId: string;
+  displayName: string;
+  connectionStatus: EnvironmentConnectionStatus;
+  freshness: Freshness;
+  lastSuccessfulInteractionUtc: string | null;
+  lastCheckedAtUtc: string | null;
+  lastErrorMessage: string | null;
+}
+
+export interface SelectedEnvironmentRecord {
+  id: 'selected-environment';
+  environmentId: string | null;
+  selectedAtUtc: string | null;
+}

--- a/src/NatsManager.Frontend/src/read-model/types/jetstream-read-model.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/jetstream-read-model.ts
@@ -1,0 +1,34 @@
+import type { HealthStatus } from './common';
+
+export interface StreamRecord {
+  id: string;
+  environmentId: string;
+  name: string;
+  description: string | null;
+  subjects: string[];
+  retentionPolicy: string;
+  storage: string;
+  replicas: number | null;
+  messages: number;
+  bytes: number;
+  consumerCount: number;
+  healthStatus: HealthStatus;
+  lastObservedAtUtc: string;
+}
+
+export interface ConsumerRecord {
+  id: string;
+  environmentId: string;
+  streamName: string;
+  name: string;
+  description: string | null;
+  durableName: string | null;
+  deliverPolicy: string;
+  ackPolicy: string;
+  pendingMessages: number | null;
+  redeliveredMessages: number | null;
+  ackFloorConsumerSequence: number | null;
+  ackFloorStreamSequence: number | null;
+  healthStatus: HealthStatus;
+  lastObservedAtUtc: string;
+}

--- a/src/NatsManager.Frontend/src/read-model/types/monitoring-read-model.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/monitoring-read-model.ts
@@ -1,0 +1,48 @@
+import type { HealthStatus, ReadModelConnectionStatus } from './common';
+
+export interface MonitoringSnapshotRecord {
+  id: string;
+  environmentId: string;
+  observedAtUtc: string;
+  receivedAtUtc: string;
+
+  healthStatus: HealthStatus;
+  status: Exclude<HealthStatus, 'Unknown'>;
+  connectionStatus: ReadModelConnectionStatus;
+
+  serverVersion: string | null;
+  connections: number;
+  totalConnections: number;
+  maxConnections: number;
+  subscriptions: number | null;
+
+  inMessagesPerSecond: number;
+  outMessagesPerSecond: number;
+  inBytesPerSecond: number;
+  outBytesPerSecond: number;
+  inMessagesTotal: number;
+  outMessagesTotal: number;
+  inBytesTotal: number;
+  outBytesTotal: number;
+
+  memoryBytes: number | null;
+  cpuPercentage: number | null;
+  uptimeSeconds: number | null;
+
+  jetStreamEnabled: boolean | null;
+  streamCount: number | null;
+  consumerCount: number | null;
+  totalMessages: number | null;
+  totalBytes: number | null;
+}
+
+export interface MonitoringEnvironmentStateRecord {
+  environmentId: string;
+  connectionStatus: ReadModelConnectionStatus;
+  healthStatus: HealthStatus;
+  latestSnapshotId: string | null;
+  lastReceivedAtUtc: string | null;
+  staleSinceUtc: string | null;
+  errorMessage: string | null;
+  isNotConfigured: boolean;
+}

--- a/src/NatsManager.Frontend/src/read-model/types/relationship-read-model.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/relationship-read-model.ts
@@ -1,0 +1,45 @@
+import type {
+  RelationshipConfidence,
+  RelationshipEvidence,
+  RelationshipFreshness,
+  RelationshipType,
+  ResourceHealthStatus,
+  ResourceType,
+} from '../../features/relationships/types';
+
+export interface RelationshipNodeRecord {
+  id: string;
+  environmentId: string;
+  resourceType: ResourceType;
+  resourceId: string;
+  label: string;
+  healthStatus: ResourceHealthStatus;
+  freshness: RelationshipFreshness;
+  detailRoute: string | null;
+  lastObservedAtUtc: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface RelationshipEdgeRecord {
+  id: string;
+  environmentId: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  relationshipType: RelationshipType;
+  confidence: RelationshipConfidence;
+  inferred: boolean;
+  stale: boolean;
+  healthStatus: ResourceHealthStatus;
+  freshness: RelationshipFreshness;
+  evidence: RelationshipEvidence[];
+  lastObservedAtUtc: string | null;
+}
+
+export interface RelationshipEvidenceRecord {
+  id: string;
+  environmentId: string;
+  edgeId: string;
+  evidenceType: string;
+  summary: string;
+  observedAtUtc: string;
+}

--- a/src/NatsManager.Frontend/src/read-model/types/resource-index-read-model.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/resource-index-read-model.ts
@@ -11,6 +11,7 @@ export type ResourceIndexType =
   | 'KvKey'
   | 'ObjectBucket'
   | 'Object'
+  | 'ObjectItem'
   | 'ObjectStoreObject'
   | 'Service'
   | 'Endpoint'

--- a/src/NatsManager.Frontend/src/read-model/types/resource-index-read-model.ts
+++ b/src/NatsManager.Frontend/src/read-model/types/resource-index-read-model.ts
@@ -1,0 +1,48 @@
+import type { Freshness, HealthStatus } from './common';
+
+export type ResourceIndexType =
+  | 'Environment'
+  | 'Server'
+  | 'Connection'
+  | 'Subject'
+  | 'Stream'
+  | 'Consumer'
+  | 'KvBucket'
+  | 'KvKey'
+  | 'ObjectBucket'
+  | 'Object'
+  | 'ObjectStoreObject'
+  | 'Service'
+  | 'Endpoint'
+  | 'ServiceEndpoint'
+  | 'Alert'
+  | 'Event'
+  | 'External'
+  | 'JetStreamAccount'
+  | 'Client'
+  | 'RelationshipNode';
+
+export interface ResourceIndexItemRecord {
+  id: string;
+  environmentId: string;
+  resourceType: ResourceIndexType;
+  resourceId: string;
+  name: string;
+  displayName: string;
+  description: string | null;
+  status: HealthStatus;
+  freshness: Freshness;
+  detailRoute: string | null;
+  searchableText: string;
+  lastObservedAtUtc: string | null;
+  indexedAtUtc: string;
+}
+
+export interface GlobalResourceSearchOptions {
+  query: string;
+  environmentId?: string | null;
+  resourceType?: string | null;
+  status?: HealthStatus | null;
+  freshness?: Freshness | null;
+  sortBy?: 'relevance' | 'resourceType' | 'name';
+}

--- a/src/NatsManager.Frontend/src/read-model/utils/collection-utils.test.ts
+++ b/src/NatsManager.Frontend/src/read-model/utils/collection-utils.test.ts
@@ -1,0 +1,16 @@
+import { calculateFreshness, makeEnvironmentScopedId } from './collection-utils';
+
+describe('read-model collection utilities', () => {
+  it('creates deterministic environment-scoped ids', () => {
+    expect(makeEnvironmentScopedId('env-1', 'Stream', 'ORDERS')).toBe('env-1:Stream:ORDERS');
+  });
+
+  it('calculates live, recent, stale, and unknown freshness', () => {
+    const now = Date.parse('2026-01-01T00:01:00.000Z');
+
+    expect(calculateFreshness('2026-01-01T00:00:55.000Z', now)).toBe('Live');
+    expect(calculateFreshness('2026-01-01T00:00:20.000Z', now)).toBe('Recent');
+    expect(calculateFreshness('2025-12-31T23:59:59.000Z', now)).toBe('Stale');
+    expect(calculateFreshness(null, now)).toBe('Unknown');
+  });
+});

--- a/src/NatsManager.Frontend/src/read-model/utils/collection-utils.ts
+++ b/src/NatsManager.Frontend/src/read-model/utils/collection-utils.ts
@@ -1,0 +1,84 @@
+import { FRESHNESS_THRESHOLDS, type Freshness } from '../types/common';
+
+interface WritableCollection {
+  readonly toArray: object[];
+  has: unknown;
+  insert: unknown;
+  update: unknown;
+  delete: unknown;
+}
+
+export function makeEnvironmentScopedId(environmentId: string, ...parts: Array<string | number | null | undefined>) {
+  return [environmentId, ...parts.map(part => String(part ?? ''))].join(':');
+}
+
+export function calculateFreshness(
+  observedAtUtc: string | null | undefined,
+  now = Date.now(),
+  thresholds = FRESHNESS_THRESHOLDS,
+): Freshness {
+  if (!observedAtUtc) return 'Unknown';
+
+  const observedAt = Date.parse(observedAtUtc);
+  if (Number.isNaN(observedAt)) return 'Unknown';
+
+  const ageMs = Math.max(0, now - observedAt);
+  if (ageMs <= thresholds.liveMs) return 'Live';
+  if (ageMs <= thresholds.recentMs) return 'Recent';
+  return 'Stale';
+}
+
+export function upsertRecord<T extends object>(
+  collection: WritableCollection,
+  key: string | number,
+  record: T,
+) {
+  const has = collection.has as (key: string | number) => boolean;
+  const insert = collection.insert as (record: T) => unknown;
+  const update = collection.update as (key: string | number, callback: (draft: T) => void) => unknown;
+
+  if (has.call(collection, key)) {
+    update.call(collection, key, (draft: T) => {
+      Object.assign(draft, record);
+    });
+    return;
+  }
+
+  insert.call(collection, record);
+}
+
+export function clearEnvironmentRecords<T extends { environmentId: string }, TKey extends string | number>(
+  collection: WritableCollection,
+  environmentId: string,
+  getKey: (record: T) => TKey,
+) {
+  const deleteRecords = collection.delete as (keys: TKey[]) => unknown;
+  const keys = (collection.toArray as T[])
+    .filter(record => record.environmentId === environmentId)
+    .map(getKey);
+
+  if (keys.length > 0) {
+    deleteRecords.call(collection, keys);
+  }
+}
+
+export function trimCollectionByEnvironment<T extends { environmentId: string }>(
+  collection: WritableCollection,
+  environmentId: string,
+  limit: number,
+  getTimestamp: (record: T) => string,
+  getKey: (record: T) => string | number,
+) {
+  const deleteRecords = collection.delete as (keys: Array<string | number>) => unknown;
+  const records = (collection.toArray as T[])
+    .filter(record => record.environmentId === environmentId)
+    .sort((left, right) => Date.parse(right ? getTimestamp(right) : '') - Date.parse(left ? getTimestamp(left) : ''));
+
+  const staleKeys = records
+    .slice(limit)
+    .map(getKey);
+
+  if (staleKeys.length > 0) {
+    deleteRecords.call(collection, staleKeys);
+  }
+}


### PR DESCRIPTION
## Summary
- add TanStack DB and the new frontend read-model layer under `src/NatsManager.Frontend/src/read-model`
- migrate monitoring, dashboard, environment state, resource indexing, relationship map sync, and JetStream metadata to read-model-backed hooks and projections
- preserve existing public hooks and keep destructive flows backend-authoritative through the existing API mutation and invalidation paths

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

Closes #112
