### PR TITLE
[codex] Add permission manifest endpoint

### DIFF
--- a/.agents/skills/speckit-analyze/SKILL.md
+++ b/.agents/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: "speckit-analyze"
+description: "Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/analyze.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit-tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit-analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit-implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit-specify with refinement", "Run /speckit-plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.agents/skills/speckit-checklist/SKILL.md
+++ b/.agents/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: "speckit-checklist"
+description: "Generate a custom checklist for the current feature based on user requirements."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/checklist.md"
+---
+
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit-checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-clarify/SKILL.md
+++ b/.agents/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: "speckit-clarify"
+description: "Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/clarify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit-plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit-specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit-plan` or run `/speckit-clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit-specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Post-Execution Checks
+
+**Check for extension hooks (after clarification)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-constitution/SKILL.md
+++ b/.agents/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: "speckit-constitution"
+description: "Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/constitution.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-implement/SKILL.md
+++ b/.agents/skills/speckit-implement/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: "speckit-implement"
+description: "Execute the implementation plan by processing and executing all tasks defined in tasks.md"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/implement.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read .specify/memory/constitution.md for governance constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit-tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-plan/SKILL.md
+++ b/.agents/skills/speckit-plan/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: "speckit-plan"
+description: "Execute the implementation planning workflow using the plan template to generate design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/plan.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/setup-plan.ps1 -Json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_plan` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Agent context update**:
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `AGENTS.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
+- ERROR on gate failures or unresolved clarifications

--- a/.agents/skills/speckit-specify/SKILL.md
+++ b/.agents/skills/speckit-specify/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: "speckit-specify"
+description: "Create or update the feature specification from a natural language feature description."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/specify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit-specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `branch_numbering`
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `.specify/templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit-plan`, `/speckit-tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit-specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+
+      ## Content Quality
+
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+
+      ## Requirement Completeness
+
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+
+      ## Feature Readiness
+
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+
+      ## Notes
+
+      - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 8
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+
+           **Context**: [Quote relevant spec section]
+
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+
+           **Suggested Answers**:
+
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+8. **Report completion** to the user with:
+   - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+   - `SPEC_FILE` — the spec file path
+   - Checklist results summary
+   - Readiness for the next phase (`/speckit-clarify` or `/speckit-plan`)
+
+9. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_specify` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.agents/skills/speckit-tasks/SKILL.md
+++ b/.agents/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: "speckit-tasks"
+description: "Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/tasks.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/setup-tasks.ps1 -Json` from repo root and parse FEATURE_DIR, TASKS_TEMPLATE, and AVAILABLE_DOCS list. `FEATURE_DIR` and `TASKS_TEMPLATE` must be absolute paths when provided. `AVAILABLE_DOCS` is a list of document names/relative paths available under `FEATURE_DIR` (for example `research.md` or `contracts/`). For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Read the tasks template from TASKS_TEMPLATE (from the JSON output above) and use it as structure. If TASKS_TEMPLATE is empty, fall back to `.specify/templates/tasks-template.md`. Fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.agents/skills/speckit-taskstoissues/SKILL.md
+++ b/.agents/skills/speckit-taskstoissues/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "speckit-taskstoissues"
+description: "Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/taskstoissues.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/003-permission-manifest"
+}

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,9 +1,10 @@
 {
-  "ai": "copilot",
+  "ai": "codex",
+  "ai_skills": true,
   "branch_numbering": "sequential",
-  "context_file": ".github/copilot-instructions.md",
+  "context_file": "AGENTS.md",
   "here": true,
-  "integration": "copilot",
-  "script": "sh",
+  "integration": "codex",
+  "script": "ps",
   "speckit_version": "0.8.13"
 }

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -2,14 +2,14 @@
   "version": "0.8.13",
   "integration_state_schema": 1,
   "installed_integrations": [
-    "copilot"
+    "codex"
   ],
   "integration_settings": {
-    "copilot": {
-      "script": "sh",
-      "invoke_separator": "."
+    "codex": {
+      "script": "ps",
+      "invoke_separator": "-"
     }
   },
-  "integration": "copilot",
-  "default_integration": "copilot"
+  "integration": "codex",
+  "default_integration": "codex"
 }

--- a/.specify/integrations/codex.manifest.json
+++ b/.specify/integrations/codex.manifest.json
@@ -1,0 +1,16 @@
+{
+  "integration": "codex",
+  "version": "0.8.13",
+  "installed_at": "2026-05-23T06:53:53.206304+00:00",
+  "files": {
+    ".agents/skills/speckit-analyze/SKILL.md": "2740b8aeab8d0104527384ca74106e252e0a20df89355c8f36be25a62130d6d6",
+    ".agents/skills/speckit-checklist/SKILL.md": "b19870b298e06c4423633b795988c3cd3d8661f1fc737f22909205861ce090d9",
+    ".agents/skills/speckit-clarify/SKILL.md": "10b3f85247bc8d3a60046f23561cd704789e7c776c5ecfe257b6338d3fca3721",
+    ".agents/skills/speckit-constitution/SKILL.md": "e2cbe859958c5a05be52a44d63821e6a84d39f3d37acc05b550cc7ad85da0dab",
+    ".agents/skills/speckit-implement/SKILL.md": "37b85cd3b960a8f242846de7fe9c777198b5f0d3da8ca40c13ca0652558799e1",
+    ".agents/skills/speckit-plan/SKILL.md": "996fa401276cce87d3d602d6e9f3cdf9fc8dec7f83c9adf3c3fd5a1a0c3540f9",
+    ".agents/skills/speckit-specify/SKILL.md": "633e9c50c22bbfa04d8690a8fc1ed89776d5820fe302380904e90f4683df4a8c",
+    ".agents/skills/speckit-tasks/SKILL.md": "74bc7f24ddd7d22ab4a82051010ca21fb54f46b5c2ff715afb35ec944147544a",
+    ".agents/skills/speckit-taskstoissues/SKILL.md": "550a58bb05a766c1115711ba50c68dbb2195af7e6c9df384a90b7143b36ffac1"
+  }
+}

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -18,6 +18,7 @@
     ".specify/scripts/bash/common.sh": "dd638316259e699fd466542c77ef16af5eb198efe0447c081f86b890db414ba8",
     ".specify/scripts/bash/create-new-feature.sh": "bcf4964ca0c6c78717bb42d9e66b8c7e5ee82779cd96afc5aa7b08b75abe5790",
     ".specify/scripts/bash/setup-plan.sh": "0d1d7a66de157b0be1385bb91aa71e5bf95550217abf47a73270dab0dc52895a",
-    ".specify/scripts/bash/setup-tasks.sh": "e8d050c63c5afb664a8b671b0b0155513fb9cab0567b335e16b9eb035482aad2"
+    ".specify/scripts/bash/setup-tasks.sh": "e8d050c63c5afb664a8b671b0b0155513fb9cab0567b335e16b9eb035482aad2",
+    ".specify/scripts/powershell/setup-tasks.ps1": "aa7b19077dc4f6feee1dae47f68dc3e6d8ac75adf572a949443f3322b753cfa2"
   }
 }

--- a/.specify/scripts/powershell/common.ps1
+++ b/.specify/scripts/powershell/common.ps1
@@ -212,7 +212,22 @@ function Get-FeaturePathsEnv {
     $repoRoot = Get-RepoRoot
     $currentBranch = Get-CurrentBranch
     $hasGit = Test-HasGit
-    $featureDir = Get-FeatureDir -RepoRoot $repoRoot -Branch $currentBranch
+
+    # Use pinned feature directory from feature.json if available and it exists on disk,
+    # otherwise derive from the current branch name.
+    $pinnedDir = Read-FeatureJsonFeatureDirectory -RepoRoot $repoRoot
+    if (-not [string]::IsNullOrWhiteSpace($pinnedDir)) {
+        if (-not [System.IO.Path]::IsPathRooted($pinnedDir)) {
+            $pinnedDir = Join-Path $repoRoot $pinnedDir
+        }
+        if (Test-Path -LiteralPath $pinnedDir -PathType Container) {
+            $featureDir = (Resolve-Path -LiteralPath $pinnedDir).Path
+        } else {
+            $featureDir = Get-FeatureDir -RepoRoot $repoRoot -Branch $currentBranch
+        }
+    } else {
+        $featureDir = Get-FeatureDir -RepoRoot $repoRoot -Branch $currentBranch
+    }
     
     [PSCustomObject]@{
         REPO_ROOT     = $repoRoot

--- a/.specify/scripts/powershell/common.ps1
+++ b/.specify/scripts/powershell/common.ps1
@@ -151,6 +151,58 @@ function Test-FeatureBranch {
     return $true
 }
 
+# Safely read .specify/feature.json's "feature_directory" value.
+# Returns an empty string if the file is missing, invalid, or does not contain the key.
+function Read-FeatureJsonFeatureDirectory {
+    param([string]$RepoRoot)
+
+    $featureJson = Join-Path $RepoRoot '.specify/feature.json'
+    if (-not (Test-Path -LiteralPath $featureJson -PathType Leaf)) {
+        return ''
+    }
+
+    try {
+        $data = Get-Content -LiteralPath $featureJson -Raw | ConvertFrom-Json
+        if ($data.feature_directory) {
+            return [string]$data.feature_directory
+        }
+    } catch {
+        return ''
+    }
+
+    return ''
+}
+
+# Returns true when .specify/feature.json pins a feature directory that exists
+# and matches the active FEATURE_DIR, allowing callers to skip branch name checks.
+function Test-FeatureJsonMatchesFeatureDir {
+    param(
+        [string]$RepoRoot,
+        [string]$ActiveFeatureDir
+    )
+
+    $featureDir = Read-FeatureJsonFeatureDirectory -RepoRoot $RepoRoot
+    if ([string]::IsNullOrWhiteSpace($featureDir)) {
+        return $false
+    }
+
+    if (-not [System.IO.Path]::IsPathRooted($featureDir)) {
+        $featureDir = Join-Path $RepoRoot $featureDir
+    }
+
+    if (-not (Test-Path -LiteralPath $featureDir -PathType Container)) {
+        return $false
+    }
+
+    try {
+        $jsonPath = (Resolve-Path -LiteralPath $featureDir).Path
+        $activePath = (Resolve-Path -LiteralPath $ActiveFeatureDir).Path
+        return [string]::Equals($jsonPath, $activePath, [System.StringComparison]::OrdinalIgnoreCase)
+    } catch {
+        return $false
+    }
+}
+
 function Get-FeatureDir {
     param([string]$RepoRoot, [string]$Branch)
     Join-Path $RepoRoot "specs/$Branch"

--- a/.specify/scripts/powershell/setup-tasks.ps1
+++ b/.specify/scripts/powershell/setup-tasks.ps1
@@ -1,0 +1,74 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Output "Usage: setup-tasks.ps1 [-Json] [-Help]"
+    exit 0
+}
+
+# Source common functions
+. "$PSScriptRoot/common.ps1"
+
+# Get feature paths and validate branch
+$paths = Get-FeaturePathsEnv
+
+# If feature.json pins an existing feature directory, branch naming is not required.
+if (-not (Test-FeatureJsonMatchesFeatureDir -RepoRoot $paths.REPO_ROOT -ActiveFeatureDir $paths.FEATURE_DIR)) {
+    if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) {
+        exit 1
+    }
+}
+
+if (-not (Test-Path $paths.IMPL_PLAN -PathType Leaf)) {
+    [Console]::Error.WriteLine("ERROR: plan.md not found in $($paths.FEATURE_DIR)")
+    [Console]::Error.WriteLine("Run /speckit.plan first to create the implementation plan.")
+    exit 1
+}
+
+if (-not (Test-Path $paths.FEATURE_SPEC -PathType Leaf)) {
+    [Console]::Error.WriteLine("ERROR: spec.md not found in $($paths.FEATURE_DIR)")
+    [Console]::Error.WriteLine("Run /speckit.specify first to create the feature structure.")
+    exit 1
+}
+
+# Build available docs list
+$docs = @()
+if (Test-Path $paths.RESEARCH) { $docs += 'research.md' }
+if (Test-Path $paths.DATA_MODEL) { $docs += 'data-model.md' }
+if ((Test-Path $paths.CONTRACTS_DIR) -and (Get-ChildItem -Path $paths.CONTRACTS_DIR -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+    $docs += 'contracts/'
+}
+if (Test-Path $paths.QUICKSTART) { $docs += 'quickstart.md' }
+
+# Resolve tasks template through override stack
+$tasksTemplate = Resolve-Template -TemplateName 'tasks-template' -RepoRoot $paths.REPO_ROOT
+if (-not $tasksTemplate -or -not (Test-Path -LiteralPath $tasksTemplate -PathType Leaf)) {
+    $expectedCoreTemplate = Join-Path $paths.REPO_ROOT '.specify/templates/tasks-template.md'
+    [Console]::Error.WriteLine("ERROR: Tasks template not found for repository root: $($paths.REPO_ROOT)`nTemplate resolution order: overrides -> presets -> extensions -> core.`nExpected shared/core template location: $expectedCoreTemplate`nTo continue, verify whether 'tasks-template.md' is available in '.specify/templates/overrides/', preset templates, extension templates, or restore the shared/core templates (for example by re-running 'specify init') so that '.specify/templates/tasks-template.md' exists.")
+    exit 1
+}
+$tasksTemplate = (Resolve-Path -LiteralPath $tasksTemplate).Path
+
+# Output results
+if ($Json) {
+    [PSCustomObject]@{
+        FEATURE_DIR    = $paths.FEATURE_DIR
+        AVAILABLE_DOCS = $docs
+        TASKS_TEMPLATE = $tasksTemplate
+    } | ConvertTo-Json -Compress
+} else {
+    Write-Output "FEATURE_DIR: $($paths.FEATURE_DIR)"
+    Write-Output "TASKS_TEMPLATE: $(if ($tasksTemplate) { $tasksTemplate } else { 'not found' })"
+    Write-Output "AVAILABLE_DOCS:"
+    Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Out-Null
+    Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Out-Null
+    Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Out-Null
+    Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Out-Null
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read:
+specs/003-permission-manifest/plan.md
+<!-- SPECKIT END -->

--- a/specs/003-permission-manifest/checklists/requirements.md
+++ b/specs/003-permission-manifest/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Application Permission Exposure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on initial review.
+- Contract details such as the well-known location are included as externally observable requirements because they define the feature's discoverability contract, not internal implementation.

--- a/specs/003-permission-manifest/contracts/api-contracts.md
+++ b/specs/003-permission-manifest/contracts/api-contracts.md
@@ -71,7 +71,7 @@ Body:
 
 ```json
 {
-  "type": "https://httpstatuses.com/503",
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.6.4",
   "title": "Permission manifest unavailable",
   "status": 503,
   "detail": "No valid permission manifest is currently available."
@@ -92,7 +92,7 @@ Body:
 
 ```json
 {
-  "type": "https://httpstatuses.com/401",
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.2",
   "title": "Unauthorized",
   "status": 401,
   "detail": "A valid permission manifest access key is required."

--- a/specs/003-permission-manifest/contracts/api-contracts.md
+++ b/specs/003-permission-manifest/contracts/api-contracts.md
@@ -42,18 +42,20 @@ Body:
   },
   "permissions": [
     {
-      "name": "read:environments",
+      "name": "environments:read",
       "description": "Allows reading registered NATS environments",
       "category": "Environments"
     },
     {
-      "name": "manage:streams",
+      "name": "jetstream-streams:write",
       "description": "Allows creating, updating, or deleting JetStream streams",
       "category": "JetStream"
     }
   ]
 }
 ```
+
+Permission names use `{aggregate-resource}:{action}` with kebab-case resource segments so consumers that support wildcard policies can derive scopes such as `environments:*` or `jetstream-streams:*` from concrete manifest permissions.
 
 ### Safe Failure: 503 Service Unavailable
 

--- a/specs/003-permission-manifest/contracts/api-contracts.md
+++ b/specs/003-permission-manifest/contracts/api-contracts.md
@@ -1,0 +1,166 @@
+# API Contract: Application Permission Exposure
+
+## GET `/.well-known/permissions`
+
+Returns the current validated permission manifest for the application, or the last valid published manifest when the current manifest source is invalid and a prior valid manifest exists.
+
+### Request
+
+```http
+GET /.well-known/permissions HTTP/1.1
+Host: example.internal
+Accept: application/json
+```
+
+Restricted deployments require a service access key header:
+
+```http
+X-Permission-Manifest-Key: <service-access-key>
+```
+
+The application validates this header against a configured base64-encoded SHA-256 hash of the service access key.
+
+Public deployments do not require authentication for this endpoint.
+
+### Success Response: 200 OK
+
+Headers:
+
+```http
+Content-Type: application/json; charset=utf-8
+X-Permission-Manifest-Source: current | last-valid
+```
+
+Body:
+
+```json
+{
+  "application": {
+    "id": "nats-manager",
+    "name": "NATS Manager",
+    "version": "1.0.0"
+  },
+  "permissions": [
+    {
+      "name": "read:environments",
+      "description": "Allows reading registered NATS environments",
+      "category": "Environments"
+    },
+    {
+      "name": "manage:streams",
+      "description": "Allows creating, updating, or deleting JetStream streams",
+      "category": "JetStream"
+    }
+  ]
+}
+```
+
+### Safe Failure: 503 Service Unavailable
+
+Returned when no valid manifest has ever been published and the current manifest cannot be validated or retrieved.
+
+Headers:
+
+```http
+Content-Type: application/problem+json
+```
+
+Body:
+
+```json
+{
+  "type": "https://httpstatuses.com/503",
+  "title": "Permission manifest unavailable",
+  "status": 503,
+  "detail": "No valid permission manifest is currently available."
+}
+```
+
+### Restricted Access Failure: 401 Unauthorized
+
+Returned when deployment exposure mode is restricted and the request omits or provides an invalid service access key.
+
+Headers:
+
+```http
+Content-Type: application/problem+json
+```
+
+Body:
+
+```json
+{
+  "type": "https://httpstatuses.com/401",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "A valid permission manifest access key is required."
+}
+```
+
+## JSON Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Permission Manifest",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "application": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["id", "name"]
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["name", "description"]
+      }
+    }
+  },
+  "required": ["application", "permissions"]
+}
+```
+
+## Contract Test Matrix
+
+| Scenario | Expected |
+|----------|----------|
+| Public mode with valid current manifest | `200`, `X-Permission-Manifest-Source: current`, required JSON shape |
+| Restricted mode without key | `401`, no permission data |
+| Restricted mode with invalid key | `401`, no permission data |
+| Restricted mode with valid key | `200`, required JSON shape |
+| Current manifest invalid with last valid manifest present | `200`, `X-Permission-Manifest-Source: last-valid`, last valid body |
+| Current manifest invalid with no prior valid manifest | `503`, problem details, no permission data |
+| Manifest contains duplicate permission names | validation failure before successful publication |
+| Manifest contains deprecated/inactive permission | permission excluded from successful manifest |

--- a/specs/003-permission-manifest/data-model.md
+++ b/specs/003-permission-manifest/data-model.md
@@ -1,0 +1,112 @@
+# Data Model: Application Permission Exposure
+
+## PermissionManifest
+
+Published document returned by `GET /.well-known/permissions`.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `application` | `ApplicationMetadata` | Yes | Must be valid |
+| `permissions` | `PermissionDefinition[]` | Yes | Must contain active permissions only; duplicate names rejected |
+
+Relationships:
+
+- Owns exactly one `ApplicationMetadata`.
+- Owns zero or more active `PermissionDefinition` items.
+- Is produced by `PermissionManifestRegistry` and published through `PermissionManifestPublisher`.
+
+## ApplicationMetadata
+
+Identity information for the publishing application.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `id` | string | Yes | Non-empty; kebab-case expected |
+| `name` | string | Yes | Non-empty human-readable name |
+| `version` | string | No | Optional application version; no separate manifest version exists |
+
+## PermissionDefinition
+
+An active application-owned authorization capability.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `name` | string | Yes | Non-empty; unique within one manifest; `{action}:{resource}` expected |
+| `description` | string | Yes | Non-empty human-readable description |
+| `category` | string | No | Optional non-empty group label when present |
+
+Rules:
+
+- Deprecated and inactive permissions are not included.
+- Permission names are case-sensitive for duplicate detection after trimming whitespace.
+- Permission names should use lowercase action/resource naming, for example `read:environments`.
+
+## PermissionManifestPublicationState
+
+In-memory state used to serve validated manifests safely.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `lastValidManifest` | `PermissionManifest?` | No | Set after successful validation |
+| `lastValidatedAt` | timestamp | No | Set after each validation attempt |
+| `lastFailureReason` | string? | No | Set after validation or source failure |
+| `status` | enum | Yes | `Valid`, `InvalidWithFallback`, or `InvalidNoFallback` |
+
+State transitions:
+
+```text
+Uninitialized
+  -> Valid                when startup validation succeeds
+  -> InvalidNoFallback    when startup validation fails
+
+Valid
+  -> Valid                when a later manifest validates successfully
+  -> InvalidWithFallback  when a later manifest fails validation
+
+InvalidWithFallback
+  -> Valid                when a later manifest validates successfully
+  -> InvalidWithFallback  when failures continue and lastValidManifest exists
+
+InvalidNoFallback
+  -> Valid                when a later manifest validates successfully
+  -> InvalidNoFallback    when failures continue and no lastValidManifest exists
+```
+
+Retrieval behavior:
+
+- `Valid`: return `lastValidManifest` with success.
+- `InvalidWithFallback`: return `lastValidManifest`, emit structured validation-failure log, and mark response source as last-valid.
+- `InvalidNoFallback`: return a safe failure response without permission data.
+
+## PermissionManifestOptions
+
+Deployment configuration owned by the web layer.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `exposureMode` | enum | Yes | Must be `Public` or `Restricted`; no implicit default in production |
+| `restrictedAccessKeyHash` | string? | Conditional | Required when `exposureMode` is `Restricted` |
+| `applicationId` | string | Yes | Non-empty; kebab-case expected |
+| `applicationName` | string | Yes | Non-empty |
+| `applicationVersion` | string? | No | Optional; may fall back to assembly informational version |
+
+Rules:
+
+- Restricted mode requires a service access key check before returning manifest content.
+- Public mode must not require session authentication.
+- All modes must log manifest retrieval attempts with exposure mode and result status.
+
+## ManifestRetrievalResult
+
+Application result consumed by the HTTP endpoint.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `manifest` | `PermissionManifest?` | Conditional | Required for successful retrieval |
+| `source` | enum | Yes | `Current` or `LastValid` for successful retrievals |
+| `failureReason` | string? | Conditional | Required for safe failure responses |
+
+Rules:
+
+- Successful retrievals always serialize `PermissionManifest`.
+- Safe failures serialize problem details, not partial manifests.

--- a/specs/003-permission-manifest/data-model.md
+++ b/specs/003-permission-manifest/data-model.md
@@ -31,7 +31,7 @@ An active application-owned authorization capability.
 
 | Field | Type | Required | Validation |
 |-------|------|----------|------------|
-| `name` | string | Yes | Non-empty; unique within one manifest; `{action}:{resource}` expected |
+| `name` | string | Yes | Non-empty; unique within one manifest; `{aggregate-resource}:{action}` expected |
 | `description` | string | Yes | Non-empty human-readable description |
 | `category` | string | No | Optional non-empty group label when present |
 
@@ -39,7 +39,8 @@ Rules:
 
 - Deprecated and inactive permissions are not included.
 - Permission names are case-sensitive for duplicate detection after trimming whitespace.
-- Permission names should use lowercase action/resource naming, for example `read:environments`.
+- Permission names should use lowercase kebab-case resource/action naming, for example `environments:read` or `jetstream-streams:write`.
+- Concrete permission names do not include wildcard entries; consumers can derive supported wildcard scopes such as `environments:*` or `jetstream-streams:*`.
 
 ## PermissionManifestPublicationState
 

--- a/specs/003-permission-manifest/plan.md
+++ b/specs/003-permission-manifest/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Application Permission Exposure
+
+**Branch**: `003-permission-manifest` | **Date**: 2026-05-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-permission-manifest/spec.md`
+
+## Summary
+
+Add a backend-only permission manifest module that publishes the application's active permissions at `/.well-known/permissions`. The manifest is code-owned by the application, validated before publication, cached as the last valid manifest, and returned through an ASP.NET Core Minimal API endpoint. Endpoint exposure is explicitly controlled by deployment configuration: public mode allows unauthenticated discovery, and restricted mode requires a configured service access key.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10 backend; TypeScript frontend unchanged
+**Primary Dependencies**: ASP.NET Core 10 Minimal APIs, `System.Text.Json`, options validation, Serilog, xUnit v3 + Shouldly + NSubstitute, `Microsoft.AspNetCore.Mvc.Testing`
+**Storage**: Code-owned static manifest source plus in-memory last-valid publication cache; no database schema change and no NATS calls
+**Testing**: xUnit v3 + MTP v2 for application and web tests; `WebApplicationFactory<Program>` for endpoint contract tests
+**Target Platform**: Existing Linux OCI-hosted NATS Manager web application; desktop/browser UI unchanged
+**Project Type**: Backend feature addition to existing SPA + ASP.NET Core Minimal API web application
+**Performance Goals**: Manifest retrieval completes from memory within 100ms p95; startup validation completes within 1s for expected permission sets; no added frontend bundle cost
+**Constraints**: Endpoint path is root-level `/.well-known/permissions`, not under `/api`; each deployment must explicitly choose public or restricted exposure; restricted exposure requires service-key validation; only active permissions are published; application version is the only version field; no IAM import, approval, assignment, or policy-enforcement workflow
+**Scale/Scope**: One well-known endpoint, one application module, one web endpoint file, one options class, application/web tests; designed for tens to hundreds of permissions with a hard validation guard against duplicate names
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Code Quality (NON-NEGOTIABLE) - PASS
+
+- Single responsibility: manifest models, validation, publication cache, access policy, and endpoint mapping are separate concerns.
+- Existing project structure is preserved; no new project or cross-module ownership change.
+- All public manifest DTOs use explicit records and nullable annotations; no `any` or untyped payloads.
+- Permission terminology is specific to application authorization and does not reuse NATS resource terms incorrectly.
+- No new external dependencies are required; existing framework, options, logging, and test packages are sufficient.
+
+### II. Testing Standards (NON-NEGOTIABLE) - PASS
+
+- Unit tests will cover manifest validation, duplicate permission rejection, active-only permission filtering, last-valid fallback, and access-policy decisions.
+- Web tests will cover `/.well-known/permissions` status codes, JSON shape, restricted access, invalid current manifest fallback, and no-prior-valid failure.
+- Contract tests will validate the endpoint response shape and headers without relying on implementation details.
+- Mocks remain at system boundaries through existing `WebApplicationFactory` and service substitutions.
+
+### III. User Experience Consistency - PASS
+
+- No UI changes are required.
+- Error responses use existing problem-result conventions where the endpoint cannot return a valid manifest.
+- Operational failures are logged with structured fields so operators can diagnose manifest validation and retrieval issues.
+
+### IV. Performance Requirements - PASS
+
+- Retrieval is served from an in-memory validated snapshot, avoiding database, NATS, and filesystem work on the request path.
+- Startup validation and manifest publication are bounded by permission list size.
+- The feature adds no frontend code and therefore no bundle, rendering, or navigation regression.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-permission-manifest/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── spec.md
+├── checklists/
+│   └── requirements.md
+└── contracts/
+    └── api-contracts.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── NatsManager.Application/
+│   └── Modules/
+│       └── Permissions/
+│           ├── Models/
+│           │   └── PermissionManifestModels.cs
+│           ├── Queries/
+│           │   └── GetPermissionManifestQuery.cs
+│           └── Services/
+│               ├── PermissionManifestRegistry.cs
+│               ├── PermissionManifestValidator.cs
+│               └── PermissionManifestPublisher.cs
+│
+└── NatsManager.Web/
+    ├── Configuration/
+    │   └── PermissionManifestOptions.cs
+    ├── Endpoints/
+    │   └── PermissionManifestEndpoints.cs
+    └── Program.cs
+
+tests/
+├── NatsManager.Application.Tests/
+│   └── Modules/
+│       └── Permissions/
+│           ├── PermissionManifestValidatorTests.cs
+│           └── PermissionManifestPublisherTests.cs
+└── NatsManager.Web.Tests/
+    └── Endpoints/
+        └── PermissionManifestEndpointTests.cs
+```
+
+**Structure Decision**: Use the existing backend Clean Architecture layout. The application layer owns the manifest data, validation, and last-valid publication behavior. The web layer owns deployment options, access policy enforcement, endpoint mapping, and HTTP response details. No frontend files and no persistence files are planned.
+
+## Phase 0 - Research
+
+Completed in [research.md](research.md). All planning unknowns are resolved with decisions for endpoint shape, manifest ownership, validation/fallback behavior, exposure policy, version semantics, and test strategy.
+
+## Phase 1 - Design & Contracts
+
+Completed artifacts:
+
+- [data-model.md](data-model.md) defines manifest entities, validation rules, and publication state transitions.
+- [contracts/api-contracts.md](contracts/api-contracts.md) defines the `GET /.well-known/permissions` contract.
+- [quickstart.md](quickstart.md) documents developer verification and manual endpoint checks.
+
+## Post-Design Constitution Check
+
+### I. Code Quality (NON-NEGOTIABLE) - PASS
+
+Design keeps manifest logic in one `Permissions` application module and endpoint concerns in one web endpoint file. No duplicate permission-shape definitions are introduced outside generated contract documentation.
+
+### II. Testing Standards (NON-NEGOTIABLE) - PASS
+
+Design includes application unit tests and web contract tests for all functional and edge-case requirements. No untestable behavior remains.
+
+### III. User Experience Consistency - PASS
+
+No UI changes are introduced. Failure states use existing API problem conventions and structured logs for operators.
+
+### IV. Performance Requirements - PASS
+
+Design keeps the request path memory-only and adds no frontend or NATS dependency. The planned verification covers retrieval latency and failure behavior without requiring new performance infrastructure.
+
+## Complexity Tracking
+
+No constitution violations. The feature is additive within existing backend modules, adds no new package dependency, and introduces no database or frontend complexity.

--- a/specs/003-permission-manifest/quickstart.md
+++ b/specs/003-permission-manifest/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Application Permission Exposure
+
+## Prerequisites
+
+- .NET SDK from `global.json`
+- Existing repository dependencies restored
+- Feature branch: `003-permission-manifest`
+
+## Configure Exposure Mode
+
+For local public discovery testing:
+
+```json
+{
+  "PermissionManifest": {
+    "ExposureMode": "Public",
+    "ApplicationId": "nats-manager",
+    "ApplicationName": "NATS Manager"
+  }
+}
+```
+
+For restricted discovery testing:
+
+```json
+{
+  "PermissionManifest": {
+    "ExposureMode": "Restricted",
+    "RestrictedAccessKeyHash": "<base64-sha256-service-access-key-hash>",
+    "ApplicationId": "nats-manager",
+    "ApplicationName": "NATS Manager"
+  }
+}
+```
+
+`RestrictedAccessKeyHash` is the base64-encoded SHA-256 hash of the service access key sent through `X-Permission-Manifest-Key`.
+
+## Run Focused Tests
+
+Application-level validation and publication behavior:
+
+```powershell
+dotnet test tests/NatsManager.Application.Tests/NatsManager.Application.Tests.csproj -- --filter-namespace NatsManager.Application.Tests.Modules.Permissions
+```
+
+HTTP endpoint contract behavior:
+
+```powershell
+dotnet test tests/NatsManager.Web.Tests/NatsManager.Web.Tests.csproj -- --filter-namespace NatsManager.Web.Tests.Endpoints --filter-class '*PermissionManifestEndpointTests'
+```
+
+HTTP option validation behavior:
+
+```powershell
+dotnet test tests/NatsManager.Web.Tests/NatsManager.Web.Tests.csproj -- --filter-namespace NatsManager.Web.Tests.Configuration --filter-class '*PermissionManifestOptionsTests'
+```
+
+## Run Full Backend Verification
+
+```powershell
+dotnet test
+```
+
+```powershell
+dotnet format --verify-no-changes
+```
+
+## Manual Endpoint Check
+
+Start the web project:
+
+```powershell
+dotnet run --project src/NatsManager.Web/NatsManager.Web.csproj
+```
+
+Fetch the manifest:
+
+```powershell
+Invoke-RestMethod -Uri "https://localhost:5001/.well-known/permissions" -Headers @{ Accept = "application/json" }
+```
+
+Restricted mode:
+
+```powershell
+Invoke-RestMethod -Uri "https://localhost:5001/.well-known/permissions" -Headers @{
+  Accept = "application/json"
+  "X-Permission-Manifest-Key" = "<service-access-key>"
+}
+```
+
+## Expected Results
+
+- Successful responses include `application.id`, `application.name`, optional `application.version`, and an array of active permissions.
+- Each permission has a unique `name` and non-empty `description`.
+- Deprecated or inactive permissions are absent.
+- Invalid current manifests return the last valid manifest when available.
+- If no valid manifest exists, the endpoint returns a safe problem response with no permission data.

--- a/specs/003-permission-manifest/quickstart.md
+++ b/specs/003-permission-manifest/quickstart.md
@@ -91,7 +91,8 @@ Invoke-RestMethod -Uri "https://localhost:5001/.well-known/permissions" -Headers
 ## Expected Results
 
 - Successful responses include `application.id`, `application.name`, optional `application.version`, and an array of active permissions.
-- Each permission has a unique `name` and non-empty `description`.
+- Each permission has a unique `{aggregate-resource}:{action}` `name` and non-empty `description`.
+- Consumers can derive wildcard scopes such as `environments:*` from concrete manifest permissions when their IAM solution supports them.
 - Deprecated or inactive permissions are absent.
 - Invalid current manifests return the last valid manifest when available.
 - If no valid manifest exists, the endpoint returns a safe problem response with no permission data.

--- a/specs/003-permission-manifest/research.md
+++ b/specs/003-permission-manifest/research.md
@@ -21,7 +21,7 @@ Create a `Permissions` module in `NatsManager.Application` with manifest models,
 **Alternatives considered**:
 
 - Store permissions in SQLite: rejected because the feature does not require runtime editing and would add persistence, migrations, and admin UI scope.
-- Generate permissions from current roles only: rejected because roles are assignment groupings, while the manifest contract describes permission capabilities using `{action}:{resource}` names.
+- Generate permissions from current roles only: rejected because roles are assignment groupings, while the manifest contract describes permission capabilities using `{aggregate-resource}:{action}` names.
 - Read a JSON file at request time: rejected because the request path should not depend on filesystem I/O and last-valid fallback needs explicit publication state.
 
 ## Decision: Validate on publication and serve the last valid manifest on current-source failure

--- a/specs/003-permission-manifest/research.md
+++ b/specs/003-permission-manifest/research.md
@@ -1,0 +1,92 @@
+# Phase 0 Research: Application Permission Exposure
+
+## Decision: Expose the manifest with a dedicated root-level Minimal API endpoint
+
+Use a new `PermissionManifestEndpoints` mapper registered from `Program.cs` with `app.MapGet("/.well-known/permissions", ...)`. The endpoint is intentionally outside existing `/api` and environment-scoped route groups because the feature contract requires a well-known discovery location independent of NATS environment context.
+
+**Rationale**: Existing endpoints are grouped by application area or environment. A well-known discovery endpoint is an application-level contract and should not inherit environment route parameters. ASP.NET Core Minimal API guidance supports `MapGet` handlers returning typed results for JSON and alternate status outcomes, which fits the 200/401/503 contract.
+
+**Alternatives considered**:
+
+- Add the route under `/api`: rejected because it breaks the well-known discovery contract.
+- Serve a static JSON file: rejected because validation, exposure policy, last-valid fallback, logging, and application version resolution are application behavior.
+- Put the endpoint into an existing access-control group: rejected because the feature publishes application-owned permissions and is not an IAM management workflow.
+
+## Decision: Keep the manifest source code-owned in the application layer
+
+Create a `Permissions` module in `NatsManager.Application` with manifest models, a registry for the active permission set, validation, and publication logic.
+
+**Rationale**: The spec says the publishing application owns the permission set. A code-owned registry keeps permission changes reviewable, testable, versioned with the application, and independent of database migrations. It also avoids coupling this feature to IAM import or assignment behavior.
+
+**Alternatives considered**:
+
+- Store permissions in SQLite: rejected because the feature does not require runtime editing and would add persistence, migrations, and admin UI scope.
+- Generate permissions from current roles only: rejected because roles are assignment groupings, while the manifest contract describes permission capabilities using `{action}:{resource}` names.
+- Read a JSON file at request time: rejected because the request path should not depend on filesystem I/O and last-valid fallback needs explicit publication state.
+
+## Decision: Validate on publication and serve the last valid manifest on current-source failure
+
+Use `PermissionManifestPublisher` as a singleton publication service with current validation status and the last valid `PermissionManifest`. Startup validation initializes the publication state. Retrieval returns the last valid manifest when current validation fails; if no prior valid manifest exists, retrieval fails safely.
+
+**Rationale**: This directly implements the clarification that invalid current manifests should not expose malformed data and should preserve discovery availability when a prior valid manifest exists. Keeping the last valid manifest in memory keeps retrieval fast and deterministic.
+
+**Alternatives considered**:
+
+- Fail every retrieval while the current manifest is invalid: rejected because it reduces availability and contradicts the selected clarification.
+- Return the invalid manifest with warnings: rejected because the spec forbids malformed or unvalidated successful manifests.
+- Fail application startup on invalid manifest: rejected because this endpoint should not take down unrelated NATS Manager functionality; the endpoint can fail safely and log loudly.
+
+## Decision: Make exposure mode explicit through validated deployment options
+
+Add `PermissionManifestOptions` in the web layer with an `ExposureMode` enum. `Public` mode returns the manifest without authentication. `Restricted` mode requires a configured service access key sent with the request and compared using constant-time validation against a stored hash or configured secret representation.
+
+**Rationale**: The spec requires each environment to explicitly declare public or restricted exposure. The existing session-auth UI model is not appropriate for external service discovery, and no IAM import workflow is in scope. A narrow service-key policy is testable, deployable behind gateway controls, and keeps the endpoint self-contained.
+
+**Alternatives considered**:
+
+- Reuse browser session authorization: rejected because external discovery consumers are service systems, not interactive users.
+- Rely only on upstream gateway policy: rejected because the spec says the application must enforce approved access controls when restricted.
+- Add OAuth2/client credentials in this feature: rejected as too broad and outside application-owned publication behavior.
+
+## Decision: Use application version only for change tracking
+
+The manifest may include `application.version`, and no separate manifest version is planned.
+
+**Rationale**: Clarification selected application version as the only version field. This keeps the payload shape close to the original contract and avoids confusing consumers with two independent version concepts.
+
+**Alternatives considered**:
+
+- Add `manifest.version`: rejected by clarification.
+- Require a version field: rejected because the spec marks version as optional and existing application version metadata may not always be available in local builds.
+
+## Decision: Publish active permissions only
+
+The registry exposes only active permissions. Deprecated or inactive permissions are excluded from the successful manifest.
+
+**Rationale**: Clarification selected active-only publication. Rename behavior is represented by adding the new active permission and removing the old permission when it is no longer active.
+
+**Alternatives considered**:
+
+- Include deprecated permissions with status: rejected by clarification.
+- Include replacement metadata: rejected by clarification and would expand lifecycle scope.
+
+## Decision: No frontend implementation is required
+
+Do not add React components, hooks, navigation, or UI tests for this feature.
+
+**Rationale**: The user-facing value is endpoint discovery by external consumers. Administrative UI grouping is supported through the manifest `category` field, but no in-app administration view is required by the specification.
+
+**Alternatives considered**:
+
+- Add an admin page to preview permissions: rejected as out of scope and unnecessary for endpoint contract validation.
+
+## Decision: Test at application and HTTP contract boundaries
+
+Use application unit tests for validation and publication state, and web tests for route, status codes, headers, access modes, and JSON shape.
+
+**Rationale**: This matches the constitution: unit tests for validation/business logic, contract tests for API boundaries, and no frontend/E2E tests when no UI behavior changes.
+
+**Alternatives considered**:
+
+- Only web tests: rejected because validation rules and fallback state are business logic.
+- Full E2E browser tests: rejected because there is no browser workflow.

--- a/specs/003-permission-manifest/spec.md
+++ b/specs/003-permission-manifest/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Application Permission Exposure
+
+**Feature Branch**: `003-permission-manifest`
+**Created**: 2026-05-23
+**Status**: Draft
+**Input**: User description: "Application Permission Exposure Specification"
+
+## Clarifications
+
+### Session 2026-05-23
+
+- Q: What should determine whether the permission manifest endpoint is public or restricted? -> A: Deployment-policy controlled; public or restricted behavior must be explicit per environment.
+- Q: What should happen when the current manifest is invalid at retrieval time? -> A: Return the last valid published manifest and record the validation failure.
+- Q: Which version field should consumers use for change tracking? -> A: Use only the application version for change tracking.
+- Q: How should deprecated permissions appear in the published manifest? -> A: Do not publish deprecated permissions; only active permissions appear.
+- Q: How quickly should permission updates appear in discovery responses? -> A: Next retrieval after successful publication.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover Application Permissions (Priority: P1)
+
+As an external consumer responsible for access management, I need to discover the complete permission set owned by an application from a predictable location so that downstream systems can understand what permissions the application publishes.
+
+**Why this priority**: Discovery of the full permission set is the core value of the feature and enables every consumer workflow.
+
+**Independent Test**: Can be fully tested by requesting the well-known permission location and confirming the response contains application metadata, all owned permissions, and human-readable permission descriptions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the application has a valid permission manifest, **When** an external consumer requests `/.well-known/permissions`, **Then** the application returns a successful JSON response containing application metadata and the full permission set.
+2. **Given** the manifest contains multiple permissions, **When** an external consumer reviews the response, **Then** each permission includes a unique name and a human-readable description.
+
+---
+
+### User Story 2 - Publish Permission Metadata for Administration (Priority: P2)
+
+As an administrator or policy tooling consumer, I need permission metadata such as categories and application identity so that permissions can be presented, grouped, and reviewed without relying on internal application knowledge.
+
+**Why this priority**: Metadata makes the manifest useful for administration and policy review beyond raw permission names.
+
+**Independent Test**: Can be tested by retrieving a manifest with categorized permissions and confirming the application identity and grouping metadata are present where defined.
+
+**Acceptance Scenarios**:
+
+1. **Given** permissions are organized by category, **When** the manifest is retrieved, **Then** category values are included with the relevant permissions.
+2. **Given** the application publishes an application version, **When** the manifest is retrieved, **Then** the version is included as application metadata without changing the required payload shape.
+
+---
+
+### User Story 3 - Reflect Permission Changes (Priority: P3)
+
+As an application owner, I need updates to the permission manifest to be reflected in future discovery responses so that consumers can detect additions, removals, and renames without tight coupling to IAM internals.
+
+**Why this priority**: Keeping the published manifest current supports ongoing permission lifecycle management after initial discovery.
+
+**Independent Test**: Can be tested by updating the manifest source, completing successful publication, and confirming the next retrieval returns the updated permission set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new permission is added to the manifest source and successfully published, **When** the manifest is retrieved next, **Then** the new permission appears with its description and any defined category.
+2. **Given** a permission is removed from the manifest source and successfully published, **When** the manifest is retrieved next, **Then** the removed permission no longer appears in the active permission list.
+3. **Given** a permission is being renamed, **When** the manifest is prepared for publication, **Then** the new active permission is represented separately and the old permission is removed from the published permission list when it is no longer active.
+
+### Edge Cases
+
+- The current manifest source is unavailable or invalid when a consumer requests the well-known location.
+- No prior valid published manifest exists when the current manifest is unavailable or invalid.
+- The manifest contains duplicate permission names.
+- The manifest omits required application metadata or permission descriptions.
+- The endpoint is deployed without an explicit public-or-restricted exposure policy for the environment.
+- A permission update occurs while consumers are retrieving the manifest.
+- Optional metadata is present that older consumers do not recognize.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The application MUST expose a discoverable permission manifest at `/.well-known/permissions`.
+- **FR-002**: The permission manifest location MUST support retrieval through a read-only request.
+- **FR-003**: The application MUST return a JSON manifest when the permission manifest is available.
+- **FR-004**: The manifest MUST include application metadata with at least a stable application identifier and a human-readable application name.
+- **FR-005**: The manifest MAY include an application version for change tracking.
+- **FR-006**: The manifest MUST include the full set of active permissions owned and published by the application.
+- **FR-007**: Each permission MUST include a permission name and a human-readable description.
+- **FR-008**: Each permission MAY include a category for administration grouping.
+- **FR-009**: The manifest payload shape MUST remain stable across compatible versions so existing consumers can continue reading required fields.
+- **FR-010**: The application MUST validate the manifest before publishing it as available.
+- **FR-011**: Manifest validation MUST reject missing required application metadata, missing permission names, missing permission descriptions, and duplicate permission names.
+- **FR-012**: Permission names SHOULD follow the `{action}:{resource}` naming pattern.
+- **FR-013**: Application identifiers SHOULD use kebab-case.
+- **FR-014**: When the current manifest cannot be validated or retrieved, the application MUST return the last valid published manifest when one exists and MUST make the failure observable to operators.
+- **FR-015**: When no prior valid manifest exists, the application MUST fail retrieval safely without returning malformed or unvalidated permission data.
+- **FR-016**: The published manifest MUST exclude deprecated or inactive permissions.
+- **FR-017**: The next manifest retrieval after successful publication MUST reflect the latest successfully published manifest after permissions are added, removed, or renamed.
+- **FR-018**: The manifest MUST NOT include internal-only metadata that is not intended for external consumers.
+- **FR-019**: Each deployment environment MUST explicitly declare whether manifest retrieval is public or restricted; if restricted, the application MUST enforce approved service-to-service access controls before returning manifest content.
+- **FR-020**: The application MUST emit structured operational records for manifest retrieval and manifest validation failures.
+- **FR-021**: The feature scope MUST be limited to application-owned publication and discovery; IAM-side import, approval, assignment, and policy enforcement behavior are out of scope.
+
+### Key Entities *(include if feature involves data)*
+
+- **Permission Manifest**: The published document that contains application metadata, the application's owned permissions, and optional non-breaking metadata for discovery.
+- **Application Metadata**: Identity information for the publishing application, including stable identifier, display name, and optional version.
+- **Permission**: A single active application-owned authorization capability, identified by name and described in human-readable language; may include category metadata.
+- **Manifest Retrieval**: A consumer request to discover the current permission manifest and the observable result recorded for operations.
+- **Manifest Validation Result**: The outcome of checking the manifest for required shape, unique permission names, and absence of restricted internal metadata before publication.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of successful manifest retrievals include application metadata and a permissions list that satisfies the required manifest shape.
+- **SC-002**: 100% of published permissions include a unique name and a non-empty human-readable description.
+- **SC-003**: 95% of consumers can retrieve and parse the manifest without prior application-specific knowledge during discovery testing.
+- **SC-004**: Permission additions, removals, and renames are visible on the next discovery response after successful publication.
+- **SC-005**: Invalid manifests are detected before successful publication in 100% of validation test cases covering missing required fields and duplicate permission names.
+- **SC-006**: 100% of invalid manifest updates preserve the last valid published manifest for retrieval when one exists.
+- **SC-007**: Administration reviewers can identify the publishing application and understand the purpose of each permission from the manifest alone in user acceptance testing.
+
+## Assumptions
+
+- The application is the authoritative owner of the permissions it publishes.
+- The manifest represents permissions intended for external discovery and excludes internal-only implementation details.
+- The well-known permission location is part of the external contract for this feature because discoverability is the primary requirement.
+- Manifest exposure is controlled by deployment policy, and each environment must explicitly declare whether retrieval is public or restricted; when restricted, trusted service access controls are handled by the hosting environment or platform policy.
+- Optional metadata such as category details must be additive and non-breaking.
+- IAM import, approval, assignment, and enforcement workflows are intentionally outside this feature's scope.

--- a/specs/003-permission-manifest/spec.md
+++ b/specs/003-permission-manifest/spec.md
@@ -86,7 +86,7 @@ As an application owner, I need updates to the permission manifest to be reflect
 - **FR-009**: The manifest payload shape MUST remain stable across compatible versions so existing consumers can continue reading required fields.
 - **FR-010**: The application MUST validate the manifest before publishing it as available.
 - **FR-011**: Manifest validation MUST reject missing required application metadata, missing permission names, missing permission descriptions, and duplicate permission names.
-- **FR-012**: Permission names SHOULD follow the `{action}:{resource}` naming pattern.
+- **FR-012**: Permission names SHOULD follow the `{aggregate-resource}:{action}` naming pattern, using kebab-case resource segments so consumers can derive `{aggregate-resource}:*` wildcard scopes where supported.
 - **FR-013**: Application identifiers SHOULD use kebab-case.
 - **FR-014**: When the current manifest cannot be validated or retrieved, the application MUST return the last valid published manifest when one exists and MUST make the failure observable to operators.
 - **FR-015**: When no prior valid manifest exists, the application MUST fail retrieval safely without returning malformed or unvalidated permission data.

--- a/specs/003-permission-manifest/tasks.md
+++ b/specs/003-permission-manifest/tasks.md
@@ -1,0 +1,229 @@
+# Tasks: Application Permission Exposure
+
+**Input**: Design documents from `/specs/003-permission-manifest/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api-contracts.md, quickstart.md
+
+**Tests**: Required by the project constitution. Test tasks appear before implementation tasks in each user story.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented, tested, and delivered independently after the shared foundation is complete.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files or does not depend on incomplete tasks
+- **[Story]**: Maps the task to a user story from spec.md
+- Every task includes an exact target path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the feature file layout and test entry points without implementing behavior.
+
+- [X] T001 Create the permissions module directory structure under `src/NatsManager.Application/Modules/Permissions/`
+- [X] T002 [P] Create the web endpoint file shell in `src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs`
+- [X] T003 [P] Create application test directory shells under `tests/NatsManager.Application.Tests/Modules/Permissions/`
+- [X] T004 [P] Create the endpoint test file shell in `tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared contracts, options, and service surfaces that all user stories depend on.
+
+**Critical**: No user story work should begin until this phase is complete.
+
+- [X] T005 [P] Define `PermissionManifest`, `ApplicationMetadata`, `PermissionDefinition`, publication status enums, and retrieval result records in `src/NatsManager.Application/Modules/Permissions/Models/PermissionManifestModels.cs`
+- [X] T006 [P] Define `GetPermissionManifestQuery` and `GetPermissionManifestQueryHandler` signatures in `src/NatsManager.Application/Modules/Permissions/Queries/GetPermissionManifestQuery.cs`
+- [X] T007 [P] Define `PermissionManifestOptions` and `PermissionManifestExposureMode` with public/restricted configuration properties in `src/NatsManager.Web/Configuration/PermissionManifestOptions.cs`
+- [X] T008 Define the validator service contract and result shape in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs`
+- [X] T009 Define the registry service contract for active application-owned permissions in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs`
+- [X] T010 Define the publisher service contract and in-memory publication state fields in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestPublisher.cs`
+
+**Checkpoint**: Foundation ready. User story implementation can now begin in priority order or in parallel across separate contributors.
+
+---
+
+## Phase 3: User Story 1 - Discover Application Permissions (Priority: P1) MVP
+
+**Goal**: `GET /.well-known/permissions` returns a successful JSON manifest with application metadata, all active owned permissions, and human-readable descriptions.
+
+**Independent Test**: Request `/.well-known/permissions` in public mode and verify HTTP 200, `application.id`, `application.name`, a permissions array, unique permission names, non-empty descriptions, and `X-Permission-Manifest-Source: current`.
+
+### Tests for User Story 1
+
+- [X] T011 [P] [US1] Add validator tests for a valid manifest and missing required application/permission fields in `tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs`
+- [X] T012 [P] [US1] Add publisher tests for successful validation, publication, and current-source retrieval in `tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs`
+- [X] T013 [P] [US1] Add public-mode endpoint contract test for HTTP 200, JSON content type, manifest shape, and current-source header in `tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Implement required-field validation for application metadata, permission names, and permission descriptions in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs`
+- [X] T015 [US1] Implement the initial active permission manifest source for NATS Manager in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs`
+- [X] T016 [US1] Implement `GetPermissionManifestQueryHandler` to retrieve the published manifest result from the publisher in `src/NatsManager.Application/Modules/Permissions/Queries/GetPermissionManifestQuery.cs`
+- [X] T017 [US1] Implement successful publication and current-source retrieval behavior in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestPublisher.cs`
+- [X] T018 [US1] Implement the public happy-path Minimal API handler for `/.well-known/permissions` in `src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs`
+- [X] T019 [US1] Register permission manifest services, options binding, and endpoint mapping in `src/NatsManager.Web/Program.cs`
+- [X] T020 [US1] Run the US1 focused tests using commands documented in `specs/003-permission-manifest/quickstart.md`
+
+**Checkpoint**: User Story 1 is functional and independently testable as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Publish Permission Metadata for Administration (Priority: P2)
+
+**Goal**: The manifest includes administration-friendly metadata such as category values and optional application version without changing the stable required payload shape.
+
+**Independent Test**: Retrieve a manifest containing categorized permissions and application version metadata, then verify categories are present where defined and required fields remain unchanged.
+
+### Tests for User Story 2
+
+- [X] T021 [P] [US2] Add validator tests for optional non-empty category values and optional application version handling in `tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs`
+- [X] T022 [P] [US2] Add endpoint contract test for categorized permissions and application version serialization in `tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs`
+- [X] T023 [P] [US2] Add options binding tests for application id, name, version, and exposure mode in `tests/NatsManager.Web.Tests/Configuration/PermissionManifestOptionsTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T024 [US2] Implement optional category and application version serialization behavior in `src/NatsManager.Application/Modules/Permissions/Models/PermissionManifestModels.cs`
+- [X] T025 [US2] Populate category metadata for published permissions in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs`
+- [X] T026 [US2] Resolve application id, name, and optional version from configured options or assembly metadata before publication in `src/NatsManager.Web/Program.cs`
+- [X] T027 [US2] Apply `PermissionManifestOptions` validation for application identity fields in `src/NatsManager.Web/Configuration/PermissionManifestOptions.cs`
+- [X] T028 [US2] Ensure endpoint responses preserve the stable required payload shape while including optional metadata in `src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs`
+- [X] T029 [US2] Run the US2 focused tests using commands documented in `specs/003-permission-manifest/quickstart.md`
+
+**Checkpoint**: User Stories 1 and 2 both work independently and the endpoint is useful for administration grouping.
+
+---
+
+## Phase 5: User Story 3 - Reflect Permission Changes (Priority: P3)
+
+**Goal**: Successful manifest updates appear on the next retrieval, invalid current manifests fall back to the last valid manifest when available, restricted deployments enforce access controls, and inactive permissions are never published.
+
+**Independent Test**: Publish an initial valid manifest, publish changed manifests with additions/removals/renames, verify the next retrieval reflects the latest successful publication, then verify invalid current manifests return last-valid or 503 according to prior valid state.
+
+### Tests for User Story 3
+
+- [X] T030 [P] [US3] Add publisher tests for add/remove/rename update publication and next-retrieval freshness in `tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs`
+- [X] T031 [US3] Add publisher tests for invalid-current fallback and invalid-no-fallback states in `tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs`
+- [X] T032 [P] [US3] Add validator tests for duplicate permission names and inactive permission exclusion in `tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs`
+- [X] T033 [P] [US3] Add endpoint tests for last-valid `200` responses and no-valid-manifest `503` problem responses in `tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs`
+- [X] T034 [US3] Add endpoint tests for restricted mode missing key, invalid key, and valid key responses in `tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T035 [US3] Implement duplicate permission name rejection and trimmed field validation in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs`
+- [X] T036 [US3] Implement active-only registry entries so deprecated and inactive permissions are excluded from published manifests in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs`
+- [X] T037 [US3] Implement publication state transitions for `Valid`, `InvalidWithFallback`, and `InvalidNoFallback` in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestPublisher.cs`
+- [X] T038 [US3] Implement next-retrieval freshness after successful publish operations in `src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestPublisher.cs`
+- [X] T039 [US3] Implement restricted-mode service key comparison and unauthorized problem responses in `src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs`
+- [X] T040 [US3] Implement `503` problem responses and `X-Permission-Manifest-Source` header selection for current versus last-valid retrievals in `src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs`
+- [X] T041 [US3] Enforce explicit exposure mode and restricted key configuration validation in `src/NatsManager.Web/Configuration/PermissionManifestOptions.cs`
+- [X] T042 [US3] Emit structured logs for manifest retrieval results and validation failures in `src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs`
+- [X] T043 [US3] Wire startup publication validation so the first retrieval uses validated state in `src/NatsManager.Web/Program.cs`
+- [X] T044 [US3] Run the US3 focused tests using commands documented in `specs/003-permission-manifest/quickstart.md`
+
+**Checkpoint**: All user stories are independently functional and the endpoint handles update, fallback, and restricted-access scenarios.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, cleanup, and documentation alignment across the feature.
+
+- [X] T045 [P] Update manual verification notes for final option names and endpoint behavior in `specs/003-permission-manifest/quickstart.md`
+- [X] T046 [P] Review the API contract for any implementation-aligned header or problem-details wording updates in `specs/003-permission-manifest/contracts/api-contracts.md`
+- [X] T047 Verify no frontend changes are required or accidentally introduced under `src/NatsManager.Frontend/`
+- [X] T048 Run full backend test verification from `specs/003-permission-manifest/quickstart.md`
+- [X] T049 Run formatting verification from `specs/003-permission-manifest/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories.
+- **User Stories (Phases 3-5)**: Depend on Foundational completion.
+- **Polish (Phase 6)**: Depends on completion of the desired user stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Starts after Foundational; no dependency on other user stories; MVP scope.
+- **User Story 2 (P2)**: Starts after Foundational; can build on the same manifest model but remains independently testable through metadata assertions.
+- **User Story 3 (P3)**: Starts after Foundational; can be implemented after US1 for simplest sequencing because fallback behavior relies on the same publisher contract, but tests isolate update and access-policy behavior.
+
+### Within Each User Story
+
+- Write story tests first and verify they fail before implementation.
+- Implement application validation and publication behavior before endpoint response behavior.
+- Register services and options before running web endpoint tests.
+- Complete each story checkpoint before moving to the next priority when working sequentially.
+
+---
+
+## Parallel Opportunities
+
+- T002, T003, and T004 can run in parallel after T001 because they touch different files.
+- T005, T006, and T007 can run in parallel during Foundational work.
+- T011, T012, and T013 can run in parallel for US1 test-first development.
+- T021, T022, and T023 can run in parallel for US2 test-first development.
+- T030, T032, and T033 can be split across application and web test files for US3 while T031 and T034 sequence behind same-file test edits.
+- T045 and T046 can run in parallel during polish because they update separate documentation files.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T011 [P] [US1] Add validator tests for a valid manifest and missing required application/permission fields in tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs"
+Task: "T012 [P] [US1] Add publisher tests for successful validation, publication, and current-source retrieval in tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs"
+Task: "T013 [P] [US1] Add public-mode endpoint contract test for HTTP 200, JSON content type, manifest shape, and current-source header in tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T021 [P] [US2] Add validator tests for optional non-empty category values and optional application version handling in tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs"
+Task: "T022 [P] [US2] Add endpoint contract test for categorized permissions and application version serialization in tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs"
+Task: "T023 [P] [US2] Add options binding tests for application id, name, version, and exposure mode in tests/NatsManager.Web.Tests/Configuration/PermissionManifestOptionsTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T030 [P] [US3] Add publisher tests for add/remove/rename update publication and next-retrieval freshness in tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs"
+Task: "T032 [P] [US3] Add validator tests for duplicate permission names and inactive permission exclusion in tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs"
+Task: "T033 [P] [US3] Add endpoint tests for last-valid 200 responses and no-valid-manifest 503 problem responses in tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational contracts and service surfaces.
+3. Complete Phase 3: User Story 1.
+4. Stop and validate US1 with the focused application and web tests from `specs/003-permission-manifest/quickstart.md`.
+
+### Incremental Delivery
+
+1. Deliver US1 to expose the core well-known permission manifest.
+2. Deliver US2 to enrich the manifest for administration grouping and version-aware review.
+3. Deliver US3 to handle manifest lifecycle updates, fallback behavior, and restricted deployments.
+4. Run full backend verification and formatting before completion.
+
+### Parallel Team Strategy
+
+1. Complete Setup and Foundational work together.
+2. Split tests by boundary: application validator/publisher tests and web endpoint contract tests.
+3. Implement application-layer behavior before web-layer response behavior for each story.
+4. Integrate through `Program.cs` only after the relevant service behavior is covered by tests.
+
+---
+
+## Notes
+
+- Do not add frontend implementation for this feature unless the specification changes.
+- Keep the endpoint at root path `/.well-known/permissions`; do not place it under `/api`.
+- Successful responses serialize only active permissions and must never return unvalidated manifest data.
+- Restricted mode must be explicit per deployment and must not rely on browser session authentication.

--- a/src/NatsManager.AppHost/NatsManager.AppHost.csproj
+++ b/src/NatsManager.AppHost/NatsManager.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/NatsManager.Application/Modules/Permissions/Models/PermissionManifestModels.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Models/PermissionManifestModels.cs
@@ -1,0 +1,51 @@
+namespace NatsManager.Application.Modules.Permissions.Models;
+
+public sealed record PermissionManifest(
+    ApplicationMetadata Application,
+    IReadOnlyList<PermissionDefinition> Permissions);
+
+public sealed record ApplicationMetadata(
+    string Id,
+    string Name,
+    string? Version = null);
+
+public sealed record PermissionDefinition(
+    string Name,
+    string Description,
+    string? Category = null);
+
+public enum PermissionManifestPublicationStatus
+{
+    Valid,
+    InvalidWithFallback,
+    InvalidNoFallback
+}
+
+public enum PermissionManifestSource
+{
+    Current,
+    LastValid
+}
+
+public sealed record PermissionManifestPublicationState(
+    PermissionManifest? LastValidManifest,
+    DateTimeOffset? LastValidatedAt,
+    string? LastFailureReason,
+    PermissionManifestPublicationStatus Status);
+
+public sealed record ManifestRetrievalResult(
+    PermissionManifest? Manifest,
+    PermissionManifestSource? Source,
+    string? FailureReason)
+{
+    public bool IsSuccess => Manifest is not null;
+
+    public static ManifestRetrievalResult Current(PermissionManifest manifest) =>
+        new(manifest, PermissionManifestSource.Current, null);
+
+    public static ManifestRetrievalResult LastValid(PermissionManifest manifest, string? failureReason) =>
+        new(manifest, PermissionManifestSource.LastValid, failureReason);
+
+    public static ManifestRetrievalResult Failure(string failureReason) =>
+        new(null, null, failureReason);
+}

--- a/src/NatsManager.Application/Modules/Permissions/Queries/GetPermissionManifestQuery.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Queries/GetPermissionManifestQuery.cs
@@ -1,0 +1,23 @@
+using NatsManager.Application.Common;
+using NatsManager.Application.Modules.Permissions.Models;
+using NatsManager.Application.Modules.Permissions.Services;
+
+namespace NatsManager.Application.Modules.Permissions.Queries;
+
+public sealed record GetPermissionManifestQuery;
+
+public sealed class GetPermissionManifestQueryHandler(
+    IPermissionManifestPublisher publisher)
+    : IUseCase<GetPermissionManifestQuery, ManifestRetrievalResult>
+{
+    private readonly IPermissionManifestPublisher publisher = publisher;
+
+    public Task ExecuteAsync(
+        GetPermissionManifestQuery request,
+        IOutputPort<ManifestRetrievalResult> outputPort,
+        CancellationToken cancellationToken = default)
+    {
+        outputPort.Success(publisher.GetManifest());
+        return Task.CompletedTask;
+    }
+}

--- a/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestPublisher.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestPublisher.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.Logging;
+using NatsManager.Application.Modules.Permissions.Models;
+
+namespace NatsManager.Application.Modules.Permissions.Services;
+
+public interface IPermissionManifestPublisher
+{
+    PermissionManifestPublicationState State { get; }
+
+    PermissionManifestPublicationResult Publish(PermissionManifest? manifest);
+
+    ManifestRetrievalResult GetManifest();
+}
+
+public sealed record PermissionManifestPublicationResult(
+    PermissionManifestPublicationStatus Status,
+    bool Published,
+    string? FailureReason);
+
+public sealed class PermissionManifestPublisher(
+    IPermissionManifestValidator validator,
+    ILogger<PermissionManifestPublisher> logger) : IPermissionManifestPublisher
+{
+    private static readonly Action<ILogger, PermissionManifestPublicationStatus, string, Exception?> LogManifestValidationFailed =
+        LoggerMessage.Define<PermissionManifestPublicationStatus, string>(
+            LogLevel.Warning,
+            new EventId(1000, nameof(LogManifestValidationFailed)),
+            "Permission manifest validation failed with status {Status}: {FailureReason}");
+
+    private readonly IPermissionManifestValidator validator = validator;
+    private readonly ILogger<PermissionManifestPublisher> logger = logger;
+    private readonly object gate = new();
+    private PermissionManifestPublicationState state =
+        new(null, null, null, PermissionManifestPublicationStatus.InvalidNoFallback);
+
+    public PermissionManifestPublicationState State
+    {
+        get
+        {
+            lock (gate)
+            {
+                return state;
+            }
+        }
+    }
+
+    public PermissionManifestPublicationResult Publish(PermissionManifest? manifest)
+    {
+        var validation = validator.Validate(manifest);
+        var validatedAt = DateTimeOffset.UtcNow;
+
+        lock (gate)
+        {
+            if (validation.IsValid)
+            {
+                state = new PermissionManifestPublicationState(
+                    manifest,
+                    validatedAt,
+                    null,
+                    PermissionManifestPublicationStatus.Valid);
+
+                return new PermissionManifestPublicationResult(
+                    PermissionManifestPublicationStatus.Valid,
+                    Published: true,
+                    FailureReason: null);
+            }
+
+            var failureReason = string.Join("; ", validation.Errors);
+            var status = state.LastValidManifest is null
+                ? PermissionManifestPublicationStatus.InvalidNoFallback
+                : PermissionManifestPublicationStatus.InvalidWithFallback;
+
+            LogManifestValidationFailed(logger, status, failureReason, null);
+
+            state = new PermissionManifestPublicationState(
+                state.LastValidManifest,
+                validatedAt,
+                failureReason,
+                status);
+
+            return new PermissionManifestPublicationResult(
+                status,
+                Published: false,
+                failureReason);
+        }
+    }
+
+    public ManifestRetrievalResult GetManifest()
+    {
+        lock (gate)
+        {
+            if (state.Status == PermissionManifestPublicationStatus.Valid
+                && state.LastValidManifest is not null)
+            {
+                return ManifestRetrievalResult.Current(state.LastValidManifest);
+            }
+
+            if (state.Status == PermissionManifestPublicationStatus.InvalidWithFallback
+                && state.LastValidManifest is not null)
+            {
+                return ManifestRetrievalResult.LastValid(
+                    state.LastValidManifest,
+                    state.LastFailureReason);
+            }
+
+            return ManifestRetrievalResult.Failure(
+                state.LastFailureReason ?? "No valid permission manifest is currently available.");
+        }
+    }
+}

--- a/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs
@@ -1,0 +1,60 @@
+using NatsManager.Application.Modules.Permissions.Models;
+
+namespace NatsManager.Application.Modules.Permissions.Services;
+
+public interface IPermissionManifestRegistry
+{
+    PermissionManifest CreateManifest(ApplicationMetadata application);
+}
+
+public sealed record PermissionManifestRegistryEntry(
+    string Name,
+    string Description,
+    string? Category = null,
+    bool IsActive = true);
+
+public sealed class PermissionManifestRegistry : IPermissionManifestRegistry
+{
+    private readonly IReadOnlyList<PermissionManifestRegistryEntry> entries;
+
+    public PermissionManifestRegistry(IEnumerable<PermissionManifestRegistryEntry> entries)
+    {
+        this.entries = entries.ToArray();
+    }
+
+    public static PermissionManifestRegistry CreateDefault() =>
+        new(DefaultEntries);
+
+    public PermissionManifest CreateManifest(ApplicationMetadata application)
+    {
+        var activePermissions = entries
+            .Where(entry => entry.IsActive)
+            .Select(entry => new PermissionDefinition(
+                entry.Name.Trim(),
+                entry.Description.Trim(),
+                NormalizeOptional(entry.Category)))
+            .ToArray();
+
+        return new PermissionManifest(application, activePermissions);
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static readonly IReadOnlyList<PermissionManifestRegistryEntry> DefaultEntries =
+    [
+        new("read:environments", "Allows reading registered NATS environments", "Environments"),
+        new("write:environments", "Allows creating or modifying registered NATS environments", "Environments"),
+        new("read:streams", "Allows reading JetStream stream definitions and status", "JetStream"),
+        new("write:streams", "Allows creating, updating, or deleting JetStream streams", "JetStream"),
+        new("read:consumers", "Allows reading JetStream consumer definitions and status", "JetStream"),
+        new("write:consumers", "Allows creating, updating, or deleting JetStream consumers", "JetStream"),
+        new("read:key-value", "Allows reading Key Value bucket metadata and entries", "Key Value"),
+        new("write:key-value", "Allows creating, updating, or deleting Key Value bucket entries", "Key Value"),
+        new("read:object-store", "Allows reading Object Store bucket metadata and objects", "Object Store"),
+        new("write:object-store", "Allows creating, updating, or deleting Object Store buckets and objects", "Object Store"),
+        new("read:services", "Allows reading NATS service discovery information", "Services"),
+        new("read:audit-events", "Allows reading audit event history", "Audit"),
+        new("manage:access-control", "Allows managing users, roles, and role assignments", "Access Control")
+    ];
+}

--- a/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs
@@ -43,18 +43,18 @@ public sealed class PermissionManifestRegistry : IPermissionManifestRegistry
 
     private static readonly IReadOnlyList<PermissionManifestRegistryEntry> DefaultEntries =
     [
-        new("read:environments", "Allows reading registered NATS environments", "Environments"),
-        new("write:environments", "Allows creating or modifying registered NATS environments", "Environments"),
-        new("read:streams", "Allows reading JetStream stream definitions and status", "JetStream"),
-        new("write:streams", "Allows creating, updating, or deleting JetStream streams", "JetStream"),
-        new("read:consumers", "Allows reading JetStream consumer definitions and status", "JetStream"),
-        new("write:consumers", "Allows creating, updating, or deleting JetStream consumers", "JetStream"),
-        new("read:key-value", "Allows reading Key Value bucket metadata and entries", "Key Value"),
-        new("write:key-value", "Allows creating, updating, or deleting Key Value bucket entries", "Key Value"),
-        new("read:object-store", "Allows reading Object Store bucket metadata and objects", "Object Store"),
-        new("write:object-store", "Allows creating, updating, or deleting Object Store buckets and objects", "Object Store"),
-        new("read:services", "Allows reading NATS service discovery information", "Services"),
-        new("read:audit-events", "Allows reading audit event history", "Audit"),
-        new("manage:access-control", "Allows managing users, roles, and role assignments", "Access Control")
+        new("environments:read", "Allows reading registered NATS environments", "Environments"),
+        new("environments:write", "Allows creating or modifying registered NATS environments", "Environments"),
+        new("jetstream-streams:read", "Allows reading JetStream stream definitions and status", "JetStream"),
+        new("jetstream-streams:write", "Allows creating, updating, or deleting JetStream streams", "JetStream"),
+        new("jetstream-consumers:read", "Allows reading JetStream consumer definitions and status", "JetStream"),
+        new("jetstream-consumers:write", "Allows creating, updating, or deleting JetStream consumers", "JetStream"),
+        new("key-value:read", "Allows reading Key Value bucket metadata and entries", "Key Value"),
+        new("key-value:write", "Allows creating, updating, or deleting Key Value bucket entries", "Key Value"),
+        new("object-store:read", "Allows reading Object Store bucket metadata and objects", "Object Store"),
+        new("object-store:write", "Allows creating, updating, or deleting Object Store buckets and objects", "Object Store"),
+        new("services:read", "Allows reading NATS service discovery information", "Services"),
+        new("audit-events:read", "Allows reading audit event history", "Audit"),
+        new("access-control:manage", "Allows managing users, roles, and role assignments", "Access Control")
     ];
 }

--- a/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestRegistry.cs
@@ -41,14 +41,16 @@ public sealed class PermissionManifestRegistry : IPermissionManifestRegistry
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
+    private const string JetStreamCategory = "JetStream";
+
     private static readonly IReadOnlyList<PermissionManifestRegistryEntry> DefaultEntries =
     [
         new("environments:read", "Allows reading registered NATS environments", "Environments"),
         new("environments:write", "Allows creating or modifying registered NATS environments", "Environments"),
-        new("jetstream-streams:read", "Allows reading JetStream stream definitions and status", "JetStream"),
-        new("jetstream-streams:write", "Allows creating, updating, or deleting JetStream streams", "JetStream"),
-        new("jetstream-consumers:read", "Allows reading JetStream consumer definitions and status", "JetStream"),
-        new("jetstream-consumers:write", "Allows creating, updating, or deleting JetStream consumers", "JetStream"),
+        new("jetstream-streams:read", "Allows reading JetStream stream definitions and status", JetStreamCategory),
+        new("jetstream-streams:write", "Allows creating, updating, or deleting JetStream streams", JetStreamCategory),
+        new("jetstream-consumers:read", "Allows reading JetStream consumer definitions and status", JetStreamCategory),
+        new("jetstream-consumers:write", "Allows creating, updating, or deleting JetStream consumers", JetStreamCategory),
         new("key-value:read", "Allows reading Key Value bucket metadata and entries", "Key Value"),
         new("key-value:write", "Allows creating, updating, or deleting Key Value bucket entries", "Key Value"),
         new("object-store:read", "Allows reading Object Store bucket metadata and objects", "Object Store"),

--- a/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs
@@ -29,24 +29,36 @@ public sealed class PermissionManifestValidator : IPermissionManifestValidator
             return PermissionManifestValidationResult.Failure(errors);
         }
 
-        if (string.IsNullOrWhiteSpace(manifest.Application.Id))
+        ValidateApplication(manifest.Application, errors);
+        ValidatePermissions(manifest.Permissions, errors);
+
+        return errors.Count == 0
+            ? PermissionManifestValidationResult.Success
+            : PermissionManifestValidationResult.Failure(errors);
+    }
+
+    private static void ValidateApplication(ApplicationMetadata application, List<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(application.Id))
         {
             errors.Add("Application id is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(manifest.Application.Name))
+        if (string.IsNullOrWhiteSpace(application.Name))
         {
             errors.Add("Application name is required.");
         }
 
-        if (manifest.Application.Version is not null
-            && string.IsNullOrWhiteSpace(manifest.Application.Version))
+        if (application.Version is not null && string.IsNullOrWhiteSpace(application.Version))
         {
             errors.Add("Application version must be non-empty when provided.");
         }
+    }
 
+    private static void ValidatePermissions(IReadOnlyList<PermissionDefinition> permissions, List<string> errors)
+    {
         var permissionNames = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var permission in manifest.Permissions)
+        foreach (var permission in permissions)
         {
             var trimmedName = permission.Name?.Trim();
             if (string.IsNullOrWhiteSpace(trimmedName))
@@ -70,9 +82,5 @@ public sealed class PermissionManifestValidator : IPermissionManifestValidator
                 errors.Add($"Permission category must be non-empty when provided for '{trimmedName}'.");
             }
         }
-
-        return errors.Count == 0
-            ? PermissionManifestValidationResult.Success
-            : PermissionManifestValidationResult.Failure(errors);
     }
 }

--- a/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs
+++ b/src/NatsManager.Application/Modules/Permissions/Services/PermissionManifestValidator.cs
@@ -1,0 +1,78 @@
+using NatsManager.Application.Modules.Permissions.Models;
+
+namespace NatsManager.Application.Modules.Permissions.Services;
+
+public interface IPermissionManifestValidator
+{
+    PermissionManifestValidationResult Validate(PermissionManifest? manifest);
+}
+
+public sealed record PermissionManifestValidationResult(
+    bool IsValid,
+    IReadOnlyList<string> Errors)
+{
+    public static PermissionManifestValidationResult Success { get; } = new(true, []);
+
+    public static PermissionManifestValidationResult Failure(IReadOnlyList<string> errors) =>
+        new(false, errors);
+}
+
+public sealed class PermissionManifestValidator : IPermissionManifestValidator
+{
+    public PermissionManifestValidationResult Validate(PermissionManifest? manifest)
+    {
+        var errors = new List<string>();
+
+        if (manifest is null)
+        {
+            errors.Add("Permission manifest is required.");
+            return PermissionManifestValidationResult.Failure(errors);
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Application.Id))
+        {
+            errors.Add("Application id is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Application.Name))
+        {
+            errors.Add("Application name is required.");
+        }
+
+        if (manifest.Application.Version is not null
+            && string.IsNullOrWhiteSpace(manifest.Application.Version))
+        {
+            errors.Add("Application version must be non-empty when provided.");
+        }
+
+        var permissionNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var permission in manifest.Permissions)
+        {
+            var trimmedName = permission.Name?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmedName))
+            {
+                errors.Add("Permission name is required.");
+                continue;
+            }
+
+            if (!permissionNames.Add(trimmedName))
+            {
+                errors.Add($"Duplicate permission name '{trimmedName}'.");
+            }
+
+            if (string.IsNullOrWhiteSpace(permission.Description))
+            {
+                errors.Add($"Permission description is required for '{trimmedName}'.");
+            }
+
+            if (permission.Category is not null && string.IsNullOrWhiteSpace(permission.Category))
+            {
+                errors.Add($"Permission category must be non-empty when provided for '{trimmedName}'.");
+            }
+        }
+
+        return errors.Count == 0
+            ? PermissionManifestValidationResult.Success
+            : PermissionManifestValidationResult.Failure(errors);
+    }
+}

--- a/src/NatsManager.Web/Configuration/PermissionManifestOptions.cs
+++ b/src/NatsManager.Web/Configuration/PermissionManifestOptions.cs
@@ -1,0 +1,76 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NatsManager.Web.Configuration;
+
+public sealed class PermissionManifestOptions
+{
+    public const string SectionName = "PermissionManifest";
+
+    public PermissionManifestExposureMode ExposureMode { get; init; }
+
+    public string? RestrictedAccessKeyHash { get; init; }
+
+    public string ApplicationId { get; init; } = string.Empty;
+
+    public string ApplicationName { get; init; } = string.Empty;
+
+    public string? ApplicationVersion { get; init; }
+
+    public static bool IsValid(PermissionManifestOptions options)
+    {
+        if (options.ExposureMode is not (PermissionManifestExposureMode.Public or PermissionManifestExposureMode.Restricted))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ApplicationId)
+            || string.IsNullOrWhiteSpace(options.ApplicationName))
+        {
+            return false;
+        }
+
+        if (options.ApplicationVersion is not null
+            && string.IsNullOrWhiteSpace(options.ApplicationVersion))
+        {
+            return false;
+        }
+
+        if (options.ExposureMode == PermissionManifestExposureMode.Restricted)
+        {
+            return IsSha256Hash(options.RestrictedAccessKeyHash);
+        }
+
+        return true;
+    }
+
+    public static string HashAccessKey(string accessKey)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(accessKey));
+        return Convert.ToBase64String(hash);
+    }
+
+    private static bool IsSha256Hash(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            return Convert.FromBase64String(value).Length == 32;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}
+
+public enum PermissionManifestExposureMode
+{
+    Unspecified,
+    Public,
+    Restricted
+}

--- a/src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs
+++ b/src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Options;
 using NatsManager.Application.Common;
 using NatsManager.Application.Modules.Permissions.Models;
@@ -13,6 +15,10 @@ public static class PermissionManifestEndpoints
 {
     private const string AccessKeyHeaderName = "X-Permission-Manifest-Key";
     private const string SourceHeaderName = "X-Permission-Manifest-Source";
+    private static readonly JsonSerializerOptions ManifestJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
     private static readonly Action<ILogger, PermissionManifestExposureMode, Exception?> LogRetrievalDenied =
         LoggerMessage.Define<PermissionManifestExposureMode>(
@@ -100,7 +106,7 @@ public static class PermissionManifestEndpoints
             LogLastValidServed(logger, retrieval.FailureReason, null);
         }
 
-        return Results.Json(retrieval.Manifest);
+        return Results.Json(retrieval.Manifest, ManifestJsonOptions);
     }
 
     private static bool IsAuthorized(HttpRequest request, PermissionManifestOptions options) =>

--- a/src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs
+++ b/src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs
@@ -67,11 +67,7 @@ public static class PermissionManifestEndpoints
         {
             LogRetrievalDenied(logger, options.ExposureMode, null);
 
-            return ApiProblemResults.Problem(
-                statusCode: StatusCodes.Status401Unauthorized,
-                title: "Unauthorized",
-                detail: "A valid permission manifest access key is required.",
-                type: "https://httpstatuses.com/401");
+            return ApiProblemResults.Unauthorized("A valid permission manifest access key is required.");
         }
 
         var presenter = new Presenter<ManifestRetrievalResult>();
@@ -91,7 +87,7 @@ public static class PermissionManifestEndpoints
                 statusCode: StatusCodes.Status503ServiceUnavailable,
                 title: "Permission manifest unavailable",
                 detail: "No valid permission manifest is currently available.",
-                type: "https://httpstatuses.com/503");
+                type: "https://tools.ietf.org/html/rfc9110#section-15.6.4");
         }
 
         var source = retrieval.Source == PermissionManifestSource.LastValid

--- a/src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs
+++ b/src/NatsManager.Web/Endpoints/PermissionManifestEndpoints.cs
@@ -1,0 +1,146 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+using NatsManager.Application.Common;
+using NatsManager.Application.Modules.Permissions.Models;
+using NatsManager.Application.Modules.Permissions.Queries;
+using NatsManager.Web.Configuration;
+using NatsManager.Web.Presenters;
+
+namespace NatsManager.Web.Endpoints;
+
+public static class PermissionManifestEndpoints
+{
+    private const string AccessKeyHeaderName = "X-Permission-Manifest-Key";
+    private const string SourceHeaderName = "X-Permission-Manifest-Source";
+
+    private static readonly Action<ILogger, PermissionManifestExposureMode, Exception?> LogRetrievalDenied =
+        LoggerMessage.Define<PermissionManifestExposureMode>(
+            LogLevel.Warning,
+            new EventId(1000, nameof(LogRetrievalDenied)),
+            "Permission manifest retrieval denied for exposure mode {ExposureMode}");
+
+    private static readonly Action<ILogger, string?, Exception?> LogRetrievalFailed =
+        LoggerMessage.Define<string?>(
+            LogLevel.Error,
+            new EventId(1001, nameof(LogRetrievalFailed)),
+            "Permission manifest retrieval failed with reason {FailureReason}");
+
+    private static readonly Action<ILogger, string, int, Exception?> LogRetrievalSucceeded =
+        LoggerMessage.Define<string, int>(
+            LogLevel.Information,
+            new EventId(1002, nameof(LogRetrievalSucceeded)),
+            "Permission manifest retrieved with source {ManifestSource} and permission count {PermissionCount}");
+
+    private static readonly Action<ILogger, string?, Exception?> LogLastValidServed =
+        LoggerMessage.Define<string?>(
+            LogLevel.Warning,
+            new EventId(1003, nameof(LogLastValidServed)),
+            "Permission manifest retrieval served last valid manifest because current manifest failed validation: {FailureReason}");
+
+    public static IEndpointRouteBuilder MapPermissionManifestEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/.well-known/permissions", GetPermissionManifest)
+            .WithTags("Permissions")
+            .AllowAnonymous();
+
+        return app;
+    }
+
+    private static async Task<IResult> GetPermissionManifest(
+        HttpContext httpContext,
+        IOptions<PermissionManifestOptions> optionsAccessor,
+        IUseCase<GetPermissionManifestQuery, ManifestRetrievalResult> useCase,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        var logger = loggerFactory.CreateLogger("NatsManager.Web.Endpoints.PermissionManifestEndpoints");
+        var options = optionsAccessor.Value;
+
+        if (!IsAuthorized(httpContext.Request, options))
+        {
+            LogRetrievalDenied(logger, options.ExposureMode, null);
+
+            return ApiProblemResults.Problem(
+                statusCode: StatusCodes.Status401Unauthorized,
+                title: "Unauthorized",
+                detail: "A valid permission manifest access key is required.",
+                type: "https://httpstatuses.com/401");
+        }
+
+        var presenter = new Presenter<ManifestRetrievalResult>();
+        await useCase.ExecuteAsync(new GetPermissionManifestQuery(), presenter, cancellationToken);
+
+        if (!presenter.IsSuccess || presenter.Value is null)
+        {
+            return presenter.ToResult();
+        }
+
+        var retrieval = presenter.Value;
+        if (retrieval.Manifest is null)
+        {
+            LogRetrievalFailed(logger, retrieval.FailureReason, null);
+
+            return ApiProblemResults.Problem(
+                statusCode: StatusCodes.Status503ServiceUnavailable,
+                title: "Permission manifest unavailable",
+                detail: "No valid permission manifest is currently available.",
+                type: "https://httpstatuses.com/503");
+        }
+
+        var source = retrieval.Source == PermissionManifestSource.LastValid
+            ? "last-valid"
+            : "current";
+        httpContext.Response.Headers[SourceHeaderName] = source;
+
+        LogRetrievalSucceeded(logger, source, retrieval.Manifest.Permissions.Count, null);
+
+        if (retrieval.Source == PermissionManifestSource.LastValid)
+        {
+            LogLastValidServed(logger, retrieval.FailureReason, null);
+        }
+
+        return Results.Json(retrieval.Manifest);
+    }
+
+    private static bool IsAuthorized(HttpRequest request, PermissionManifestOptions options) =>
+        options.ExposureMode switch
+        {
+            PermissionManifestExposureMode.Public => true,
+            PermissionManifestExposureMode.Restricted => HasValidAccessKey(request, options.RestrictedAccessKeyHash),
+            _ => false
+        };
+
+    private static bool HasValidAccessKey(HttpRequest request, string? configuredHash)
+    {
+        if (string.IsNullOrWhiteSpace(configuredHash)
+            || !request.Headers.TryGetValue(AccessKeyHeaderName, out var values))
+        {
+            return false;
+        }
+
+        var accessKey = values.FirstOrDefault();
+        if (string.IsNullOrEmpty(accessKey))
+        {
+            return false;
+        }
+
+        byte[] expectedHash;
+        try
+        {
+            expectedHash = Convert.FromBase64String(configuredHash);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        if (expectedHash.Length != 32)
+        {
+            return false;
+        }
+
+        var actualHash = SHA256.HashData(Encoding.UTF8.GetBytes(accessKey));
+        return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash);
+    }
+}

--- a/src/NatsManager.Web/Program.cs
+++ b/src/NatsManager.Web/Program.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Antiforgery;
@@ -11,6 +12,8 @@ using NatsManager.Application.Modules.Environments.Ports;
 using NatsManager.Application.Modules.Monitoring;
 using NatsManager.Application.Modules.Monitoring.Ports;
 using NatsManager.Application.Modules.Monitoring.Ports.ClusterObservability;
+using NatsManager.Application.Modules.Permissions.Models;
+using NatsManager.Application.Modules.Permissions.Services;
 using NatsManager.Application.Modules.Relationships.Ports;
 using NatsManager.Domain.Modules.Auth;
 using NatsManager.Infrastructure.Auth;
@@ -92,6 +95,15 @@ builder.Services.AddOptions<ObjectStoreUploadOptions>()
     .Bind(builder.Configuration.GetSection(ObjectStoreUploadOptions.SectionName))
     .Validate(ObjectStoreUploadOptions.IsValid, "ObjectStore options are invalid. MaxUploadBytes must be between 1 and 2147483647.")
     .ValidateOnStart();
+
+builder.Services.AddOptions<PermissionManifestOptions>()
+    .Bind(builder.Configuration.GetSection(PermissionManifestOptions.SectionName))
+    .Validate(PermissionManifestOptions.IsValid, "PermissionManifest options are invalid. ExposureMode must be Public or Restricted, ApplicationId and ApplicationName are required, and RestrictedAccessKeyHash must be a SHA-256 hash when restricted.")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<IPermissionManifestValidator, PermissionManifestValidator>();
+builder.Services.AddSingleton<IPermissionManifestRegistry>(_ => PermissionManifestRegistry.CreateDefault());
+builder.Services.AddSingleton<IPermissionManifestPublisher, PermissionManifestPublisher>();
 
 builder.Services.AddHttpClient("NatsMonitoring", (sp, client) =>
 {
@@ -296,6 +308,12 @@ using (var scope = app.Services.CreateScope())
 {
     var initializer = scope.ServiceProvider.GetRequiredService<DatabaseInitializer>();
     await initializer.InitializeAsync();
+
+    var manifestOptions = scope.ServiceProvider.GetRequiredService<IOptions<PermissionManifestOptions>>().Value;
+    var manifestRegistry = scope.ServiceProvider.GetRequiredService<IPermissionManifestRegistry>();
+    var manifestPublisher = scope.ServiceProvider.GetRequiredService<IPermissionManifestPublisher>();
+    manifestPublisher.Publish(manifestRegistry.CreateManifest(
+        Program.CreatePermissionManifestApplicationMetadata(manifestOptions)));
 }
 
 app.UseExceptionHandler();
@@ -379,6 +397,7 @@ app.UseMiddleware<AuditContextMiddleware>();
 app.UseMiddleware<DataFreshnessMiddleware>();
 
 app.MapDefaultEndpoints();
+app.MapPermissionManifestEndpoints();
 
 // Map SignalR hubs
 app.MapHub<MonitoringHub>("/hubs/monitoring");
@@ -422,4 +441,17 @@ app.MapFallback(async (HttpContext context, IWebHostEnvironment environment) =>
 
 app.Run();
 
-public partial class Program { }
+public partial class Program
+{
+    internal static ApplicationMetadata CreatePermissionManifestApplicationMetadata(PermissionManifestOptions options)
+    {
+        var version = !string.IsNullOrWhiteSpace(options.ApplicationVersion)
+            ? options.ApplicationVersion.Trim()
+            : typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        return new ApplicationMetadata(
+            options.ApplicationId.Trim(),
+            options.ApplicationName.Trim(),
+            string.IsNullOrWhiteSpace(version) ? null : version);
+    }
+}

--- a/src/NatsManager.Web/Program.cs
+++ b/src/NatsManager.Web/Program.cs
@@ -443,6 +443,8 @@ app.Run();
 
 public partial class Program
 {
+    protected Program() { }
+
     internal static ApplicationMetadata CreatePermissionManifestApplicationMetadata(PermissionManifestOptions options)
     {
         var version = !string.IsNullOrWhiteSpace(options.ApplicationVersion)

--- a/src/NatsManager.Web/appsettings.Development.json
+++ b/src/NatsManager.Web/appsettings.Development.json
@@ -5,6 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "PermissionManifest": {
+    "ExposureMode": "Public",
+    "ApplicationId": "nats-manager",
+    "ApplicationName": "NATS Manager"
+  },
   "CoreNats": {
     "Monitoring": {
       "DefaultPort": 8222,

--- a/src/NatsManager.Web/appsettings.json
+++ b/src/NatsManager.Web/appsettings.json
@@ -6,6 +6,11 @@
     }
   },
   "AllowedHosts": "*",
+  "PermissionManifest": {
+    "ExposureMode": "Public",
+    "ApplicationId": "nats-manager",
+    "ApplicationName": "NATS Manager"
+  },
   "CoreNats": {
     "Monitoring": {
       "DefaultPort": 8222,

--- a/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs
+++ b/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs
@@ -13,7 +13,7 @@ public sealed class PermissionManifestPublisherTests
     [Fact]
     public void Publish_WithValidManifest_ShouldStoreCurrentManifest()
     {
-        var manifest = Manifest("read:environments");
+        var manifest = Manifest("environments:read");
 
         var publishResult = publisher.Publish(manifest);
         var retrieval = publisher.GetManifest();
@@ -28,26 +28,26 @@ public sealed class PermissionManifestPublisherTests
     [Fact]
     public void Publish_WithUpdatedValidManifest_ShouldReturnLatestOnNextRetrieval()
     {
-        publisher.Publish(Manifest("read:environments"));
-        var updated = Manifest("write:environments");
+        publisher.Publish(Manifest("environments:read"));
+        var updated = Manifest("environments:write");
 
         publisher.Publish(updated);
         var retrieval = publisher.GetManifest();
 
         retrieval.Manifest.ShouldBe(updated);
-        retrieval.Manifest!.Permissions.Select(permission => permission.Name).ShouldBe(["write:environments"]);
+        retrieval.Manifest!.Permissions.Select(permission => permission.Name).ShouldBe(["environments:write"]);
         retrieval.Source.ShouldBe(PermissionManifestSource.Current);
     }
 
     [Fact]
     public void Publish_WithInvalidManifestAfterValidPublish_ShouldReturnLastValidManifest()
     {
-        var valid = Manifest("read:environments");
+        var valid = Manifest("environments:read");
         publisher.Publish(valid);
 
         var publishResult = publisher.Publish(Manifest(
-            "read:environments",
-            new PermissionDefinition(" read:environments ", "Duplicate permission", "Environments")));
+            "environments:read",
+            new PermissionDefinition(" environments:read ", "Duplicate permission", "Environments")));
         var retrieval = publisher.GetManifest();
 
         publishResult.Published.ShouldBeFalse();

--- a/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs
+++ b/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestPublisherTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NatsManager.Application.Modules.Permissions.Models;
+using NatsManager.Application.Modules.Permissions.Services;
+using Shouldly;
+
+namespace NatsManager.Application.Tests.Modules.Permissions;
+
+public sealed class PermissionManifestPublisherTests
+{
+    private readonly PermissionManifestPublisher publisher =
+        new(new PermissionManifestValidator(), NullLogger<PermissionManifestPublisher>.Instance);
+
+    [Fact]
+    public void Publish_WithValidManifest_ShouldStoreCurrentManifest()
+    {
+        var manifest = Manifest("read:environments");
+
+        var publishResult = publisher.Publish(manifest);
+        var retrieval = publisher.GetManifest();
+
+        publishResult.Published.ShouldBeTrue();
+        publishResult.Status.ShouldBe(PermissionManifestPublicationStatus.Valid);
+        retrieval.IsSuccess.ShouldBeTrue();
+        retrieval.Manifest.ShouldBe(manifest);
+        retrieval.Source.ShouldBe(PermissionManifestSource.Current);
+    }
+
+    [Fact]
+    public void Publish_WithUpdatedValidManifest_ShouldReturnLatestOnNextRetrieval()
+    {
+        publisher.Publish(Manifest("read:environments"));
+        var updated = Manifest("write:environments");
+
+        publisher.Publish(updated);
+        var retrieval = publisher.GetManifest();
+
+        retrieval.Manifest.ShouldBe(updated);
+        retrieval.Manifest!.Permissions.Select(permission => permission.Name).ShouldBe(["write:environments"]);
+        retrieval.Source.ShouldBe(PermissionManifestSource.Current);
+    }
+
+    [Fact]
+    public void Publish_WithInvalidManifestAfterValidPublish_ShouldReturnLastValidManifest()
+    {
+        var valid = Manifest("read:environments");
+        publisher.Publish(valid);
+
+        var publishResult = publisher.Publish(Manifest(
+            "read:environments",
+            new PermissionDefinition(" read:environments ", "Duplicate permission", "Environments")));
+        var retrieval = publisher.GetManifest();
+
+        publishResult.Published.ShouldBeFalse();
+        publishResult.Status.ShouldBe(PermissionManifestPublicationStatus.InvalidWithFallback);
+        retrieval.IsSuccess.ShouldBeTrue();
+        retrieval.Manifest.ShouldBe(valid);
+        retrieval.Source.ShouldBe(PermissionManifestSource.LastValid);
+        retrieval.FailureReason.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Publish_WithInvalidManifestAndNoPriorValidManifest_ShouldFailSafely()
+    {
+        var publishResult = publisher.Publish(Manifest(""));
+        var retrieval = publisher.GetManifest();
+
+        publishResult.Published.ShouldBeFalse();
+        publishResult.Status.ShouldBe(PermissionManifestPublicationStatus.InvalidNoFallback);
+        retrieval.IsSuccess.ShouldBeFalse();
+        retrieval.Manifest.ShouldBeNull();
+        retrieval.FailureReason.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    private static PermissionManifest Manifest(params object[] permissions) =>
+        new(
+            new ApplicationMetadata("nats-manager", "NATS Manager"),
+            permissions.Select(permission => permission switch
+            {
+                string name => new PermissionDefinition(name, "Allows access", "General"),
+                PermissionDefinition definition => definition,
+                _ => throw new ArgumentException("Unsupported permission test value.", nameof(permissions))
+            }).ToArray());
+}

--- a/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs
+++ b/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs
@@ -1,0 +1,144 @@
+using NatsManager.Application.Modules.Permissions.Models;
+using NatsManager.Application.Modules.Permissions.Services;
+using Shouldly;
+
+namespace NatsManager.Application.Tests.Modules.Permissions;
+
+public sealed class PermissionManifestValidatorTests
+{
+    private readonly PermissionManifestValidator validator = new();
+
+    [Fact]
+    public void Validate_WithValidManifest_ShouldPass()
+    {
+        var result = validator.Validate(ValidManifest());
+
+        result.IsValid.ShouldBeTrue();
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WithMissingApplicationId_ShouldFail()
+    {
+        var result = validator.Validate(ValidManifest(applicationId: " "));
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Application id is required.");
+    }
+
+    [Fact]
+    public void Validate_WithMissingApplicationName_ShouldFail()
+    {
+        var result = validator.Validate(ValidManifest(applicationName: ""));
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Application name is required.");
+    }
+
+    [Fact]
+    public void Validate_WithMissingPermissionName_ShouldFail()
+    {
+        var manifest = ValidManifest(permissions:
+        [
+            new PermissionDefinition("", "Allows reading environments", "Environments")
+        ]);
+
+        var result = validator.Validate(manifest);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Permission name is required.");
+    }
+
+    [Fact]
+    public void Validate_WithMissingPermissionDescription_ShouldFail()
+    {
+        var manifest = ValidManifest(permissions:
+        [
+            new PermissionDefinition("read:environments", " ", "Environments")
+        ]);
+
+        var result = validator.Validate(manifest);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Permission description is required for 'read:environments'.");
+    }
+
+    [Fact]
+    public void Validate_WithOptionalVersionAndCategory_ShouldPass()
+    {
+        var manifest = ValidManifest(
+            applicationVersion: "1.2.3",
+            permissions:
+            [
+                new PermissionDefinition("read:environments", "Allows reading environments", "Environments")
+            ]);
+
+        var result = validator.Validate(manifest);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyCategory_ShouldFail()
+    {
+        var manifest = ValidManifest(permissions:
+        [
+            new PermissionDefinition("read:environments", "Allows reading environments", "")
+        ]);
+
+        var result = validator.Validate(manifest);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Permission category must be non-empty when provided for 'read:environments'.");
+    }
+
+    [Fact]
+    public void Validate_WithEmptyApplicationVersion_ShouldFail()
+    {
+        var result = validator.Validate(ValidManifest(applicationVersion: " "));
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Application version must be non-empty when provided.");
+    }
+
+    [Fact]
+    public void Validate_WithDuplicatePermissionNameAfterTrimming_ShouldFail()
+    {
+        var manifest = ValidManifest(permissions:
+        [
+            new PermissionDefinition("read:environments", "Allows reading environments", "Environments"),
+            new PermissionDefinition(" read:environments ", "Allows reading environments again", "Environments")
+        ]);
+
+        var result = validator.Validate(manifest);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain("Duplicate permission name 'read:environments'.");
+    }
+
+    [Fact]
+    public void PermissionManifestRegistry_WithInactiveEntry_ShouldExcludeIt()
+    {
+        var registry = new PermissionManifestRegistry(
+        [
+            new PermissionManifestRegistryEntry("read:environments", "Allows reading environments", "Environments"),
+            new PermissionManifestRegistryEntry("old:environments", "Old permission", "Environments", IsActive: false)
+        ]);
+
+        var manifest = registry.CreateManifest(new ApplicationMetadata("nats-manager", "NATS Manager"));
+
+        manifest.Permissions.Select(permission => permission.Name).ShouldBe(["read:environments"]);
+    }
+
+    private static PermissionManifest ValidManifest(
+        string applicationId = "nats-manager",
+        string applicationName = "NATS Manager",
+        string? applicationVersion = null,
+        IReadOnlyList<PermissionDefinition>? permissions = null) =>
+        new(
+            new ApplicationMetadata(applicationId, applicationName, applicationVersion),
+            permissions ??
+            [
+                new PermissionDefinition("read:environments", "Allows reading environments", "Environments")
+            ]);
+}

--- a/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs
+++ b/tests/NatsManager.Application.Tests/Modules/Permissions/PermissionManifestValidatorTests.cs
@@ -54,13 +54,13 @@ public sealed class PermissionManifestValidatorTests
     {
         var manifest = ValidManifest(permissions:
         [
-            new PermissionDefinition("read:environments", " ", "Environments")
+            new PermissionDefinition("environments:read", " ", "Environments")
         ]);
 
         var result = validator.Validate(manifest);
 
         result.IsValid.ShouldBeFalse();
-        result.Errors.ShouldContain("Permission description is required for 'read:environments'.");
+        result.Errors.ShouldContain("Permission description is required for 'environments:read'.");
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public sealed class PermissionManifestValidatorTests
             applicationVersion: "1.2.3",
             permissions:
             [
-                new PermissionDefinition("read:environments", "Allows reading environments", "Environments")
+                new PermissionDefinition("environments:read", "Allows reading environments", "Environments")
             ]);
 
         var result = validator.Validate(manifest);
@@ -83,13 +83,13 @@ public sealed class PermissionManifestValidatorTests
     {
         var manifest = ValidManifest(permissions:
         [
-            new PermissionDefinition("read:environments", "Allows reading environments", "")
+            new PermissionDefinition("environments:read", "Allows reading environments", "")
         ]);
 
         var result = validator.Validate(manifest);
 
         result.IsValid.ShouldBeFalse();
-        result.Errors.ShouldContain("Permission category must be non-empty when provided for 'read:environments'.");
+        result.Errors.ShouldContain("Permission category must be non-empty when provided for 'environments:read'.");
     }
 
     [Fact]
@@ -106,14 +106,14 @@ public sealed class PermissionManifestValidatorTests
     {
         var manifest = ValidManifest(permissions:
         [
-            new PermissionDefinition("read:environments", "Allows reading environments", "Environments"),
-            new PermissionDefinition(" read:environments ", "Allows reading environments again", "Environments")
+            new PermissionDefinition("environments:read", "Allows reading environments", "Environments"),
+            new PermissionDefinition(" environments:read ", "Allows reading environments again", "Environments")
         ]);
 
         var result = validator.Validate(manifest);
 
         result.IsValid.ShouldBeFalse();
-        result.Errors.ShouldContain("Duplicate permission name 'read:environments'.");
+        result.Errors.ShouldContain("Duplicate permission name 'environments:read'.");
     }
 
     [Fact]
@@ -121,13 +121,40 @@ public sealed class PermissionManifestValidatorTests
     {
         var registry = new PermissionManifestRegistry(
         [
-            new PermissionManifestRegistryEntry("read:environments", "Allows reading environments", "Environments"),
+            new PermissionManifestRegistryEntry("environments:read", "Allows reading environments", "Environments"),
             new PermissionManifestRegistryEntry("old:environments", "Old permission", "Environments", IsActive: false)
         ]);
 
         var manifest = registry.CreateManifest(new ApplicationMetadata("nats-manager", "NATS Manager"));
 
-        manifest.Permissions.Select(permission => permission.Name).ShouldBe(["read:environments"]);
+        manifest.Permissions.Select(permission => permission.Name).ShouldBe(["environments:read"]);
+    }
+
+    [Fact]
+    public void PermissionManifestRegistry_CreateDefault_ShouldUseAggregateResourceActionNames()
+    {
+        var registry = PermissionManifestRegistry.CreateDefault();
+
+        var manifest = registry.CreateManifest(new ApplicationMetadata("nats-manager", "NATS Manager"));
+
+        manifest.Permissions.Select(permission => permission.Name).ShouldBe(
+        [
+            "environments:read",
+            "environments:write",
+            "jetstream-streams:read",
+            "jetstream-streams:write",
+            "jetstream-consumers:read",
+            "jetstream-consumers:write",
+            "key-value:read",
+            "key-value:write",
+            "object-store:read",
+            "object-store:write",
+            "services:read",
+            "audit-events:read",
+            "access-control:manage"
+        ]);
+
+        manifest.Permissions.Select(permission => permission.Name).ShouldNotContain("read:streams");
     }
 
     private static PermissionManifest ValidManifest(
@@ -139,6 +166,6 @@ public sealed class PermissionManifestValidatorTests
             new ApplicationMetadata(applicationId, applicationName, applicationVersion),
             permissions ??
             [
-                new PermissionDefinition("read:environments", "Allows reading environments", "Environments")
+                new PermissionDefinition("environments:read", "Allows reading environments", "Environments")
             ]);
 }

--- a/tests/NatsManager.E2E.Tests/Tests/CoreNatsTests.cs
+++ b/tests/NatsManager.E2E.Tests/Tests/CoreNatsTests.cs
@@ -357,7 +357,7 @@ public sealed class CoreNatsTests(AppHostFixture fixture) : E2ETestBase(fixture)
                 JsonContent($$"""{"subject":"{{subject}}","payload":"hello table"}"""));
         }
 
-        await Expect(Page.GetByRole(AriaRole.Main).GetByText(subject))
+        await Expect(ActiveSubjectRow(subject))
             .ToBeVisibleAsync(new() { Timeout = 20_000 });
     }
 
@@ -378,7 +378,7 @@ public sealed class CoreNatsTests(AppHostFixture fixture) : E2ETestBase(fixture)
                 JsonContent($$"""{"subject":"{{subject}}","payload":"hello filter"}"""));
         }
 
-        await Expect(Page.GetByRole(AriaRole.Main).GetByText(subject))
+        await Expect(ActiveSubjectRow(subject))
             .ToBeVisibleAsync(new() { Timeout = 20_000 });
 
         await Page.GetByLabel("Filter subjects").FillAsync("does.not.match");
@@ -403,9 +403,9 @@ public sealed class CoreNatsTests(AppHostFixture fixture) : E2ETestBase(fixture)
             .ToBeVisibleAsync(new() { Timeout = 10_000 });
         await Page.Keyboard.PressAsync("Escape");
 
-        await Expect(Page.GetByRole(AriaRole.Main).GetByText(subject))
+        await Expect(LiveMessageRow(subject))
             .ToBeVisibleAsync(new() { Timeout = 10_000 });
-        await Expect(Page.GetByRole(AriaRole.Table).GetByText("Hello live viewer"))
+        await Expect(LiveMessagesTable().GetByText("Hello live viewer"))
             .ToBeVisibleAsync(new() { Timeout = 10_000 });
     }
 
@@ -425,6 +425,21 @@ public sealed class CoreNatsTests(AppHostFixture fixture) : E2ETestBase(fixture)
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
+
+    private ILocator ActiveSubjectRow(string subject) =>
+        Page.GetByRole(AriaRole.Table)
+            .Filter(new() { Has = Page.GetByRole(AriaRole.Columnheader, new() { Name = "Subscriptions" }) })
+            .GetByRole(AriaRole.Row)
+            .Filter(new() { HasText = subject });
+
+    private ILocator LiveMessagesTable() =>
+        Page.GetByRole(AriaRole.Table)
+            .Filter(new() { Has = Page.GetByRole(AriaRole.Columnheader, new() { Name = "Payload Preview" }) });
+
+    private ILocator LiveMessageRow(string subject) =>
+        LiveMessagesTable()
+            .GetByRole(AriaRole.Row)
+            .Filter(new() { HasText = subject });
 
     private static StringContent JsonContent(string json) => new(json, Encoding.UTF8, "application/json");
 }

--- a/tests/NatsManager.E2E.Tests/Tests/LoginTests.cs
+++ b/tests/NatsManager.E2E.Tests/Tests/LoginTests.cs
@@ -47,8 +47,8 @@ public sealed class LoginTests(AppHostFixture fixture) : E2ETestBase(fixture)
         await Page.GetByLabel("Password").First.FillAsync("wrongpassword");
         await Page.GetByRole(AriaRole.Button, new() { Name = "Sign in" }).ClickAsync();
 
-        // Should show an error message
-        var errorAlert = Page.GetByText("Login failed", new PageGetByTextOptions { Exact = false });
+        // Should show the API-provided error message
+        var errorAlert = Page.GetByRole(AriaRole.Alert).GetByText("Invalid credentials.", new() { Exact = true });
         await Expect(errorAlert).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
         // Should stay on login page

--- a/tests/NatsManager.Infrastructure.Tests/Persistence/DatabaseInitializerPostgresTests.cs
+++ b/tests/NatsManager.Infrastructure.Tests/Persistence/DatabaseInitializerPostgresTests.cs
@@ -28,8 +28,7 @@ namespace NatsManager.Infrastructure.Tests.Persistence;
 /// </summary>
 public sealed class DatabaseInitializerPostgresTests : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:17-alpine")
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
         .WithDatabase("natsmanager")
         .WithUsername("test")
         .WithPassword("test")

--- a/tests/NatsManager.Web.Tests/Configuration/PermissionManifestOptionsTests.cs
+++ b/tests/NatsManager.Web.Tests/Configuration/PermissionManifestOptionsTests.cs
@@ -1,0 +1,86 @@
+using NatsManager.Web.Configuration;
+using Shouldly;
+
+namespace NatsManager.Web.Tests.Configuration;
+
+public sealed class PermissionManifestOptionsTests
+{
+    [Fact]
+    public void IsValid_WithPublicModeAndApplicationIdentity_ShouldPass()
+    {
+        var options = new PermissionManifestOptions
+        {
+            ExposureMode = PermissionManifestExposureMode.Public,
+            ApplicationId = "nats-manager",
+            ApplicationName = "NATS Manager"
+        };
+
+        PermissionManifestOptions.IsValid(options).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValid_WithMissingExposureMode_ShouldFail()
+    {
+        var options = new PermissionManifestOptions
+        {
+            ApplicationId = "nats-manager",
+            ApplicationName = "NATS Manager"
+        };
+
+        PermissionManifestOptions.IsValid(options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_WithRestrictedModeAndNoKeyHash_ShouldFail()
+    {
+        var options = new PermissionManifestOptions
+        {
+            ExposureMode = PermissionManifestExposureMode.Restricted,
+            ApplicationId = "nats-manager",
+            ApplicationName = "NATS Manager"
+        };
+
+        PermissionManifestOptions.IsValid(options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_WithRestrictedModeAndKeyHash_ShouldPass()
+    {
+        var options = new PermissionManifestOptions
+        {
+            ExposureMode = PermissionManifestExposureMode.Restricted,
+            RestrictedAccessKeyHash = PermissionManifestOptions.HashAccessKey("service-secret"),
+            ApplicationId = "nats-manager",
+            ApplicationName = "NATS Manager"
+        };
+
+        PermissionManifestOptions.IsValid(options).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValid_WithMissingApplicationIdentity_ShouldFail()
+    {
+        var options = new PermissionManifestOptions
+        {
+            ExposureMode = PermissionManifestExposureMode.Public,
+            ApplicationId = "",
+            ApplicationName = " "
+        };
+
+        PermissionManifestOptions.IsValid(options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_WithEmptyVersion_ShouldFail()
+    {
+        var options = new PermissionManifestOptions
+        {
+            ExposureMode = PermissionManifestExposureMode.Public,
+            ApplicationId = "nats-manager",
+            ApplicationName = "NATS Manager",
+            ApplicationVersion = " "
+        };
+
+        PermissionManifestOptions.IsValid(options).ShouldBeFalse();
+    }
+}

--- a/tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs
+++ b/tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs
@@ -1,0 +1,187 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NatsManager.Application.Modules.Permissions.Models;
+using NatsManager.Application.Modules.Permissions.Services;
+using NatsManager.Web.Configuration;
+using Shouldly;
+
+namespace NatsManager.Web.Tests.Endpoints;
+
+public sealed class PermissionManifestEndpointTests : IClassFixture<NatsManagerWebAppFactory>
+{
+    private readonly NatsManagerWebAppFactory factory;
+
+    public PermissionManifestEndpointTests(NatsManagerWebAppFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    [Fact]
+    public async Task GetPermissions_InPublicMode_ShouldReturnManifest()
+    {
+        using var client = factory.CreateAnonymousClient();
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("application/json");
+        response.Headers.GetValues("X-Permission-Manifest-Source").Single().ShouldBe("current");
+
+        using var document = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        var root = document.RootElement;
+        root.GetProperty("application").GetProperty("id").GetString().ShouldBe("nats-manager");
+        root.GetProperty("application").GetProperty("name").GetString().ShouldBe("NATS Manager");
+        root.GetProperty("permissions").GetArrayLength().ShouldBeGreaterThan(0);
+        root.GetProperty("permissions")[0].GetProperty("name").GetString().ShouldNotBeNullOrWhiteSpace();
+        root.GetProperty("permissions")[0].GetProperty("description").GetString().ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task GetPermissions_WithVersionAndCategories_ShouldReturnOptionalMetadata()
+    {
+        await using var app = factory.WithPermissionManifestConfiguration(new Dictionary<string, string?>
+        {
+            ["PermissionManifest:ApplicationVersion"] = "1.2.3"
+        });
+        using var client = app.CreateClient();
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var document = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        document.RootElement.GetProperty("application").GetProperty("version").GetString().ShouldBe("1.2.3");
+        var hasCategory = document.RootElement.GetProperty("permissions")
+            .EnumerateArray()
+            .Any(permission => permission.TryGetProperty("category", out var category)
+                && !string.IsNullOrWhiteSpace(category.GetString()));
+        hasCategory.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetPermissions_WhenLastValidManifestIsUsed_ShouldReturnLastValidSourceHeader()
+    {
+        var manifest = TestManifest("read:environments");
+        await using var app = factory.WithPublisher(new StubPermissionManifestPublisher(
+            ManifestRetrievalResult.LastValid(manifest, "Current manifest is invalid.")));
+        using var client = app.CreateClient();
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.GetValues("X-Permission-Manifest-Source").Single().ShouldBe("last-valid");
+        using var document = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        document.RootElement.GetProperty("permissions")[0].GetProperty("name").GetString().ShouldBe("read:environments");
+    }
+
+    [Fact]
+    public async Task GetPermissions_WhenNoValidManifestExists_ShouldReturn503Problem()
+    {
+        await using var app = factory.WithPublisher(new StubPermissionManifestPublisher(
+            ManifestRetrievalResult.Failure("No valid permission manifest is currently available.")));
+        using var client = app.CreateClient();
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("application/problem+json");
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Title.ShouldBe("Permission manifest unavailable");
+        problem.Status.ShouldBe(503);
+    }
+
+    [Fact]
+    public async Task GetPermissions_InRestrictedModeWithoutKey_ShouldReturn401()
+    {
+        await using var app = factory.WithRestrictedPermissionManifest("service-secret");
+        using var client = app.CreateClient();
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetPermissions_InRestrictedModeWithInvalidKey_ShouldReturn401()
+    {
+        await using var app = factory.WithRestrictedPermissionManifest("service-secret");
+        using var client = app.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Permission-Manifest-Key", "wrong-secret");
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetPermissions_InRestrictedModeWithValidKey_ShouldReturnManifest()
+    {
+        await using var app = factory.WithRestrictedPermissionManifest("service-secret");
+        using var client = app.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Permission-Manifest-Key", "service-secret");
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.GetValues("X-Permission-Manifest-Source").Single().ShouldBe("current");
+    }
+
+    private static PermissionManifest TestManifest(string permissionName) =>
+        new(
+            new ApplicationMetadata("nats-manager", "NATS Manager"),
+            [new PermissionDefinition(permissionName, "Allows reading environments", "Environments")]);
+
+    private sealed class StubPermissionManifestPublisher(
+        ManifestRetrievalResult retrievalResult) : IPermissionManifestPublisher
+    {
+        public PermissionManifestPublicationState State { get; private set; } =
+            new(null, null, null, PermissionManifestPublicationStatus.InvalidNoFallback);
+
+        public PermissionManifestPublicationResult Publish(PermissionManifest? manifest) =>
+            new(PermissionManifestPublicationStatus.Valid, true, null);
+
+        public ManifestRetrievalResult GetManifest() => retrievalResult;
+    }
+}
+
+internal static class PermissionManifestEndpointTestFactoryExtensions
+{
+    public static WebApplicationFactory<Program> WithPermissionManifestConfiguration(
+        this NatsManagerWebAppFactory factory,
+        IDictionary<string, string?> configuration) =>
+        factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(configuration);
+            });
+        });
+
+    public static WebApplicationFactory<Program> WithRestrictedPermissionManifest(
+        this NatsManagerWebAppFactory factory,
+        string accessKey) =>
+        factory.WithPermissionManifestConfiguration(new Dictionary<string, string?>
+        {
+            ["PermissionManifest:ExposureMode"] = "Restricted",
+            ["PermissionManifest:RestrictedAccessKeyHash"] = PermissionManifestOptions.HashAccessKey(accessKey)
+        });
+
+    public static WebApplicationFactory<Program> WithPublisher(
+        this NatsManagerWebAppFactory factory,
+        IPermissionManifestPublisher publisher) =>
+        factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IPermissionManifestPublisher>();
+                services.AddSingleton(publisher);
+            });
+        });
+}

--- a/tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs
+++ b/tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs
@@ -72,6 +72,24 @@ public sealed class PermissionManifestEndpointTests : IClassFixture<NatsManagerW
     }
 
     [Fact]
+    public async Task GetPermissions_WhenOptionalFieldsAreNull_ShouldOmitNullProperties()
+    {
+        var manifest = new PermissionManifest(
+            new ApplicationMetadata("nats-manager", "NATS Manager"),
+            [new PermissionDefinition("environments:read", "Allows reading environments")]);
+        await using var app = factory.WithPublisher(new StubPermissionManifestPublisher(
+            ManifestRetrievalResult.Current(manifest)));
+        using var client = app.CreateClient();
+
+        using var response = await client.GetAsync("/.well-known/permissions");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var document = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        document.RootElement.GetProperty("application").TryGetProperty("version", out _).ShouldBeFalse();
+        document.RootElement.GetProperty("permissions")[0].TryGetProperty("category", out _).ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task GetPermissions_WhenLastValidManifestIsUsed_ShouldReturnLastValidSourceHeader()
     {
         var manifest = TestManifest("environments:read");

--- a/tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs
+++ b/tests/NatsManager.Web.Tests/Endpoints/PermissionManifestEndpointTests.cs
@@ -40,7 +40,13 @@ public sealed class PermissionManifestEndpointTests : IClassFixture<NatsManagerW
         root.GetProperty("application").GetProperty("id").GetString().ShouldBe("nats-manager");
         root.GetProperty("application").GetProperty("name").GetString().ShouldBe("NATS Manager");
         root.GetProperty("permissions").GetArrayLength().ShouldBeGreaterThan(0);
-        root.GetProperty("permissions")[0].GetProperty("name").GetString().ShouldNotBeNullOrWhiteSpace();
+        var permissionNames = root.GetProperty("permissions")
+            .EnumerateArray()
+            .Select(permission => permission.GetProperty("name").GetString())
+            .ToArray();
+        permissionNames.ShouldContain("environments:read");
+        permissionNames.ShouldContain("jetstream-streams:read");
+        permissionNames.ShouldNotContain("read:environments");
         root.GetProperty("permissions")[0].GetProperty("description").GetString().ShouldNotBeNullOrWhiteSpace();
     }
 
@@ -68,7 +74,7 @@ public sealed class PermissionManifestEndpointTests : IClassFixture<NatsManagerW
     [Fact]
     public async Task GetPermissions_WhenLastValidManifestIsUsed_ShouldReturnLastValidSourceHeader()
     {
-        var manifest = TestManifest("read:environments");
+        var manifest = TestManifest("environments:read");
         await using var app = factory.WithPublisher(new StubPermissionManifestPublisher(
             ManifestRetrievalResult.LastValid(manifest, "Current manifest is invalid.")));
         using var client = app.CreateClient();
@@ -78,7 +84,7 @@ public sealed class PermissionManifestEndpointTests : IClassFixture<NatsManagerW
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.GetValues("X-Permission-Manifest-Source").Single().ShouldBe("last-valid");
         using var document = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
-        document.RootElement.GetProperty("permissions")[0].GetProperty("name").GetString().ShouldBe("read:environments");
+        document.RootElement.GetProperty("permissions")[0].GetProperty("name").GetString().ShouldBe("environments:read");
     }
 
     [Fact]

--- a/tests/NatsManager.Web.Tests/NatsManagerWebAppFactory.cs
+++ b/tests/NatsManager.Web.Tests/NatsManagerWebAppFactory.cs
@@ -58,7 +58,10 @@ public sealed class NatsManagerWebAppFactory : WebApplicationFactory<Program>
             {
                 ["BootstrapAdmin:Username"] = BootstrapAdminUsername,
                 ["BootstrapAdmin:Password"] = BootstrapAdminPassword,
-                ["Encryption:Key"] = EncryptionKey
+                ["Encryption:Key"] = EncryptionKey,
+                ["PermissionManifest:ExposureMode"] = "Public",
+                ["PermissionManifest:ApplicationId"] = "nats-manager",
+                ["PermissionManifest:ApplicationName"] = "NATS Manager"
             });
         });
 


### PR DESCRIPTION
## Summary

Adds an application-owned permission manifest endpoint at `/.well-known/permissions` with startup publication, validation, optional restricted access, and last-valid fallback behavior.

## Changes

- Added permission manifest models, validator, registry, publisher, and query handler.
- Exposed `GET /.well-known/permissions` from the web app with public/restricted configuration support.
- Added app settings and web test factory configuration for manifest exposure.
- Added focused application, options, endpoint, and E2E regression tests.
- Updated Spec Kit artifacts for the permission manifest feature and added local Spec Kit/Codex integration metadata.
- Fixed Testcontainers PostgreSQL obsolete API usage and tightened E2E selectors around current UI behavior.

## Impact

External systems can discover the application permission set directly from the well-known endpoint without coupling to IAM import or assignment internals. Restricted mode can validate a service key using a configured SHA-256 hash.

## Validation

- `dotnet test` passed: 591 total, 590 succeeded, 1 skipped, 0 failed.
- `dotnet format --verify-no-changes` passed.
- `git diff --cached --check` passed before commit.