### PR TITLE
perf: parallelize /jsz and /healthz fetches in NatsMonitoringHttpAdapter

### DIFF
--- a/src/NatsManager.Infrastructure/Nats/NatsMonitoringHttpAdapter.cs
+++ b/src/NatsManager.Infrastructure/Nats/NatsMonitoringHttpAdapter.cs
@@ -35,7 +35,7 @@ public sealed partial class NatsMonitoringHttpAdapter(
             return NatsMonitoringStateFactory.CreateSnapshot(environment.Id, MonitoringStatus.Degraded, MonitoringStatus.Unavailable);
         }
 
-        var jszResult = await client.GetJsonWithHandlingAsync<NatsJszResponse>(
+        var jszTask = client.GetJsonWithHandlingAsync<NatsJszResponse>(
             $"{baseUrl}/jsz",
             ct,
             async (response, cancellationToken) =>
@@ -50,13 +50,7 @@ public sealed partial class NatsMonitoringHttpAdapter(
                 return await response.ReadJsonOrFailureAsync<NatsJszResponse>(cancellationToken);
             });
 
-        var degraded = jszResult.FailureKind != MonitoringFailureKind.None;
-        if (jszResult.FailureKind != MonitoringFailureKind.None)
-        {
-            LogFetchFailed($"{baseUrl}/jsz", jszResult.ErrorMessage ?? UnknownError);
-        }
-
-        var healthzResult = await client.GetJsonWithHandlingAsync<NatsHealthzResponse>(
+        var healthzTask = client.GetJsonWithHandlingAsync<NatsHealthzResponse>(
             $"{baseUrl}/healthz",
             ct,
             async (response, cancellationToken) =>
@@ -68,6 +62,17 @@ public sealed partial class NatsMonitoringHttpAdapter(
 
                 return await response.ReadJsonOrFailureAsync<NatsHealthzResponse>(cancellationToken);
             });
+
+        await Task.WhenAll(jszTask, healthzTask);
+
+        var jszResult = await jszTask;
+        var healthzResult = await healthzTask;
+
+        var degraded = jszResult.FailureKind != MonitoringFailureKind.None;
+        if (jszResult.FailureKind != MonitoringFailureKind.None)
+        {
+            LogFetchFailed($"{baseUrl}/jsz", jszResult.ErrorMessage ?? UnknownError);
+        }
 
         var healthStatus = GetHealthStatus(healthzResult);
 


### PR DESCRIPTION
## Summary

Parallelizes the `/jsz` and `/healthz` HTTP calls in `NatsMonitoringHttpAdapter.FetchSnapshotAsync` using `Task.WhenAll`.

## Problem

These two calls were awaited **sequentially** even though they are completely independent:

```csharp
// Before: sequential — full round-trip latency for each
var jszResult     = await client.GetJsonWithHandlingAsync(baseUrl + "/jsz", ...);
var healthzResult = await client.GetJsonWithHandlingAsync(baseUrl + "/healthz", ...);
```

With a 5 s NATS monitoring timeout, a worst-case poll takes **10 s** just for these two calls.

## Fix

Fan them out concurrently, matching the pattern already used by `NatsClusterMonitoringHttpAdapter` (which correctly uses `Task.WhenAll` for its 6 endpoints):

```csharp
// After: parallel — both in-flight simultaneously
var jszTask     = client.GetJsonWithHandlingAsync(baseUrl + "/jsz", ...);
var healthzTask = client.GetJsonWithHandlingAsync(baseUrl + "/healthz", ...);
await Task.WhenAll(jszTask, healthzTask);
```

## Impact

- **Latency saved per poll cycle per environment:** ~1 full network round-trip (~50–5000 ms depending on timeouts/latency)
- **Runs on every monitoring poll cycle** — savings compound with number of environments and poll frequency
- No behavioural change: error handling, degraded-status logic, and logging are identical

## Related performance opportunities (identified but not in scope)

This is issue #3 from a broader audit of 16 performance improvements. Other high-priority items include:

1. **N+1 in dashboard** — `ListConsumersAsync` called per stream sequentially (High impact / Medium effort)
2. **Sequential health poller** — `EnvironmentHealthPoller` checks environments one-by-one (High impact / Low effort)
3. **`ServerMetricsChart` missing `useMemo`** — chart data recomputed on every SignalR push (High impact / Low effort)
4. **Two DB queries per request in `SessionAuthHandler`** — user + roles fetched separately (High impact / Medium effort)
5. **SQLite audit paging loads full table into memory** — unbounded allocation as audit log grows (High impact / High effort)
