### PR TITLE
docs: expand copilot-instructions with backend build/test commands and gotchas

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,11 +33,44 @@ specs/                           # SpecKit feature artifacts
 
 ## Commands
 
-npm test; npm run lint
+### Frontend
+```bash
+cd src/NatsManager.Frontend
+npm test        # Vitest unit tests
+npm run lint    # ESLint
+```
+
+### Backend — Build
+```bash
+# Solution file is NatsManager.slnx (Aspire format — no .sln exists)
+dotnet build NatsManager.slnx -c Debug
+
+# dotnet build only accepts ONE project path at a time (MSB1008 with multiple paths)
+dotnet build src/NatsManager.Web/NatsManager.Web.csproj -c Debug
+```
+
+### Backend — Run Tests
+**`dotnet test` does NOT work** — it reports 0 tests (exit code 5) with xUnit v3 + Microsoft Testing Platform v2.
+Run the built `.exe` directly:
+```bash
+tests\NatsManager.Domain.Tests\bin\Debug\net10.0\NatsManager.Domain.Tests.exe
+tests\NatsManager.Application.Tests\bin\Debug\net10.0\NatsManager.Application.Tests.exe
+tests\NatsManager.Infrastructure.Tests\bin\Debug\net10.0\NatsManager.Infrastructure.Tests.exe
+tests\NatsManager.Web.Tests\bin\Debug\net10.0\NatsManager.Web.Tests.exe
+```
+
+### Backend — Warnings-as-errors
+`src/` projects have warnings-as-errors enabled; test projects do not. Common build-breaking warnings:
+- **CA1859** — use `ConfigurationManager` (concrete type) instead of `IConfiguration` when the concrete type flows in
+- **CA1725** — parameter names on overrides/implementations must exactly match the interface
+- **Unused `using` directives** — remove after refactoring endpoint files
 
 ## Code Style
 
 C# / .NET 10 (backend), TypeScript (frontend): Follow standard conventions
+
+### File editing gotcha
+The `create` tool **cannot overwrite existing files**. To replace an existing file from scratch, create a `.new` temp file then use `Move-Item -Force`. Use the `edit` tool for all partial edits to existing files.
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,8 +50,7 @@ dotnet build src/NatsManager.Web/NatsManager.Web.csproj -c Debug
 ```
 
 ### Backend — Run Tests
-**`dotnet test` does NOT work** — it reports 0 tests (exit code 5) with xUnit v3 + Microsoft Testing Platform v2.
-Run the built `.exe` directly:
+Plain `dotnet test` from the repository root is not the supported all-backend test command with xUnit v3 + Microsoft Testing Platform v2. Run unit test projects explicitly (as CI does):
 ```bash
 tests\NatsManager.Domain.Tests\bin\Debug\net10.0\NatsManager.Domain.Tests.exe
 tests\NatsManager.Application.Tests\bin\Debug\net10.0\NatsManager.Application.Tests.exe

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ npm run lint    # ESLint
 
 ### Backend — Build
 ```bash
-# Solution file is NatsManager.slnx (Aspire format — no .sln exists)
+# Solution file is NatsManager.slnx (XML solution format — no .sln exists)
 dotnet build NatsManager.slnx -c Debug
 
 # dotnet build only accepts ONE project path at a time (MSB1008 with multiple paths)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,10 +52,10 @@ dotnet build src/NatsManager.Web/NatsManager.Web.csproj -c Debug
 ### Backend — Run Tests
 Plain `dotnet test` from the repository root is not the supported all-backend test command with xUnit v3 + Microsoft Testing Platform v2. Run unit test projects explicitly (as CI does):
 ```bash
-tests\NatsManager.Domain.Tests\bin\Debug\net10.0\NatsManager.Domain.Tests.exe
-tests\NatsManager.Application.Tests\bin\Debug\net10.0\NatsManager.Application.Tests.exe
-tests\NatsManager.Infrastructure.Tests\bin\Debug\net10.0\NatsManager.Infrastructure.Tests.exe
-tests\NatsManager.Web.Tests\bin\Debug\net10.0\NatsManager.Web.Tests.exe
+dotnet test --project tests/NatsManager.Domain.Tests/NatsManager.Domain.Tests.csproj --configuration Debug
+dotnet test --project tests/NatsManager.Application.Tests/NatsManager.Application.Tests.csproj --configuration Debug
+dotnet test --project tests/NatsManager.Infrastructure.Tests/NatsManager.Infrastructure.Tests.csproj --configuration Debug
+dotnet test --project tests/NatsManager.Web.Tests/NatsManager.Web.Tests.csproj --configuration Debug
 ```
 
 ### Backend — Warnings-as-errors


### PR DESCRIPTION
The existing `copilot-instructions.md` had only a single-line Commands section (`npm test; npm run lint`) with no backend guidance at all. Session history analysis revealed the same hard-won facts being rediscovered and re-documented in every checkpoint, causing repeated friction.

## What changed

Replaced the minimal Commands section with structured Frontend and Backend subsections covering the non-obvious parts of this repo's dev loop:

- **`dotnet test` does not work** -- xUnit v3 + Microsoft Testing Platform v2 causes it to report 0 tests (exit code 5). Tests must be run by invoking the built `.exe` directly.
- **Solution file is `NatsManager.slnx`** (Aspire format; no `.sln` exists). `dotnet build` only accepts one project path at a time -- passing multiple causes MSB1008.
- **Warnings-as-errors in `src/` projects** -- CA1859, CA1725, and unused `using` directives all become build errors. Test projects allow warnings.
- **`create` tool cannot overwrite existing files** -- a `.new` temp file + `Move-Item -Force` workaround is needed when replacing a file from scratch.

None of these are discoverable from reading a single file; they require running into the failures first. Putting them in copilot-instructions means future sessions start with this context instead of having to rediscover it.